### PR TITLE
docs: add initial documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 homepage = "https://deno.land/"
 license = "MIT"
 repository = "https://github.com/denoland/deno_ast"
-description = "AST related functionality for deno"
+description = "Source text parsing, lexing, and AST related functionality for Deno"
 
 [features]
 bundler = ["swc_bundler"]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,31 @@
 # deno_ast
 
-AST related functionality for Deno.
+[![](https://img.shields.io/crates/v/deno_ast.svg)](https://crates.io/crates/deno_ast) [![Discord Chat](https://img.shields.io/discord/684898665143206084?logo=discord&style=social)](https://discord.gg/deno)
 
-Documentation will follow in the future...
+Source text parsing, lexing, and AST related functionality for [Deno](https://deno.land).
+
+```rust
+use deno::ast::MediaType;
+use deno::ast::parse_module;
+use deno::ast::ParseParams;
+use deno::ast::SourceTextInfo;
+
+let source_text = Arc::new("class MyClass {}");
+let source_text_info = SourceTextInfo::new(source_text);
+let parsed_source = parse_module(ParseParams {
+  specifier: "file:///my_file.ts".to_string(),
+  media_type: MediaType::TypeScript,
+  source: source_text_info,
+  capture_tokens: true,
+  maybe_syntax: None,
+}).expect("should parse");
+
+// returns the comments
+parsed_source.comments();
+// returns the tokens if captured
+parsed_source.tokens();
+// returns the module (AST)
+parsed_source.module();
+// returns the `SourceTextInfo`
+parsed_source.source();
+```

--- a/src/comments.rs
+++ b/src/comments.rs
@@ -19,12 +19,16 @@ struct MultiThreadedCommentsInner {
 /// to support being used in multi-threaded code. This implementation
 /// is immutable and should you need mutability you may create a copy
 /// by converting it to an swc `SingleThreadedComments`.
+///
+/// When using this, you will want to use the
+/// `deno_ast::swc::common::comments::Comments` trait.
 #[derive(Clone, Debug)]
 pub struct MultiThreadedComments {
   inner: Arc<MultiThreadedCommentsInner>,
 }
 
 impl MultiThreadedComments {
+  /// Creates a new `MultiThreadedComments` from an swc `SingleThreadedComments`.
   pub fn from_single_threaded(comments: SingleThreadedComments) -> Self {
     let (leading, trailing) = comments.take_all();
     let leading = Rc::try_unwrap(leading).unwrap().into_inner();
@@ -34,6 +38,10 @@ impl MultiThreadedComments {
     }
   }
 
+  /// Gets a clone of the underlying data as `SingleThreadedComments`.
+  ///
+  /// This may be useful for getting a mutable data structure for use
+  /// when transpiling.
   pub fn as_single_threaded(&self) -> SingleThreadedComments {
     let inner = &self.inner;
     let leading = Rc::new(RefCell::new(inner.leading.to_owned()));
@@ -41,10 +49,12 @@ impl MultiThreadedComments {
     SingleThreadedComments::from_leading_and_trailing(leading, trailing)
   }
 
+  /// Gets a reference to the leading comment map.
   pub fn leading_map(&self) -> &SingleThreadedCommentsMapInner {
     &self.inner.leading
   }
 
+  /// Gets a reference to the trailing comment map.
   pub fn trailing_map(&self) -> &SingleThreadedCommentsMapInner {
     &self.inner.trailing
   }

--- a/src/lexing.rs
+++ b/src/lexing.rs
@@ -20,10 +20,14 @@ pub enum TokenOrComment {
 }
 
 pub struct LexedItem {
+  /// Range of the token or comment.
   pub span: Span,
+  /// Token or comment.
   pub inner: TokenOrComment,
 }
 
+/// Given the source text and media type, tokenizes the provided
+/// text to a collecion of tokens and comments.
 pub fn lex(source: &str, media_type: MediaType) -> Vec<LexedItem> {
   let comments = SingleThreadedComments::default();
   let lexer = Lexer::new(

--- a/src/parsed_source.rs
+++ b/src/parsed_source.rs
@@ -123,7 +123,13 @@ impl fmt::Debug for ParsedSource {
 
 #[cfg(feature = "view")]
 impl ParsedSource {
-  /// Gets a view of the module that allows for
+  /// Gets a dprint-swc-ecma-ast-view of the module.
+  ///
+  /// This provides a closure to examine an "ast view" of the swc AST
+  /// which has more helper methods and allows for going up the ancestors
+  /// of a node.
+  ///
+  /// Read more: https://github.com/dprint/dprint-swc-ecma-ast-view
   pub fn with_view<'a, T>(
     &self,
     with_view: impl FnOnce(crate::view::Program<'a>) -> T,
@@ -134,7 +140,7 @@ impl ParsedSource {
         Program::Script(script) => crate::view::ProgramRef::Script(script),
       },
       source_file: Some(self.source()),
-      tokens: Some(self.tokens()),
+      tokens: self.tokens.as_ref().map(|t| t as &[TokenAndSpan]),
       comments: Some(crate::view::Comments {
         leading: self.comments().leading_map(),
         trailing: self.comments().trailing_map(),

--- a/src/parsed_source.rs
+++ b/src/parsed_source.rs
@@ -15,8 +15,11 @@ use crate::MediaType;
 use crate::SourceTextInfo;
 
 /// A parsed source containing an AST, comments, and possibly tokens.
+///
+/// Note: This struct is cheap to clone.
 #[derive(Clone)]
 pub struct ParsedSource {
+  // keep this struct cheap to clone
   specifier: String,
   media_type: MediaType,
   source: SourceTextInfo,

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -18,20 +18,52 @@ use crate::MediaType;
 use crate::ParsedSource;
 use crate::SourceTextInfo;
 
+/// Ecmascript version used for lexing and parsing.
 pub const TARGET: JscTarget = JscTarget::Es2021;
 
+/// Parameters for parsing.
 pub struct ParseParams {
+  /// Specifier of the source text.
   pub specifier: String,
+  /// Source text stored in a `SourceTextInfo`.
   pub source: SourceTextInfo,
+  /// Media type of the source text.
   pub media_type: MediaType,
+  /// Whether to capture tokens or not.
   pub capture_tokens: bool,
+  /// Syntax to use when parsing.
+  ///
+  /// `deno_ast` will get a default `Syntax` to use based on the
+  /// media type, but you may use this to provide a custom `Syntax`.
   pub maybe_syntax: Option<Syntax>,
 }
 
+/// Parses the provided information attempting to figure out if the provided
+/// text is for a script or a module.
 pub fn parse_program(params: ParseParams) -> Result<ParsedSource, Diagnostic> {
   parse(params, ParseMode::Program, |p| p)
 }
 
+/// Parses the provided information as a program with the option of providing some
+/// post-processing to the result.
+///
+/// # Example
+///
+/// ```
+/// deno_ast::parse_program_with_post_process(
+///  deno_ast::ParseParams {
+///    specifier: "file:///my-file.ts".to_string(),
+///    media_type: deno_ast::MediaType::TypeScript,
+///    source: deno_ast::SourceTextInfo::from_string("".to_string()),
+///    capture_tokens: true,
+///    maybe_syntax: None,
+///  },
+///  |program| {
+///    // do something with the program here before it gets stored
+///    program
+///  },
+/// );
+/// ```
 pub fn parse_program_with_post_process(
   params: ParseParams,
   post_process: impl FnOnce(Program) -> Program,
@@ -39,10 +71,12 @@ pub fn parse_program_with_post_process(
   parse(params, ParseMode::Program, post_process)
 }
 
+/// Parses the provided information to a module.
 pub fn parse_module(params: ParseParams) -> Result<ParsedSource, Diagnostic> {
   parse(params, ParseMode::Module, |p| p)
 }
 
+/// Parses the provided information to a script.
 pub fn parse_script(params: ParseParams) -> Result<ParsedSource, Diagnostic> {
   parse(params, ParseMode::Script, |p| p)
 }
@@ -121,6 +155,7 @@ fn parse_string_input(
   }
 }
 
+/// Gets the default `Syntax` used by `deno_ast` for the provided media type.
 pub fn get_syntax(media_type: MediaType) -> Syntax {
   match media_type {
     MediaType::JavaScript => Syntax::Es(get_es_config(false)),
@@ -132,6 +167,7 @@ pub fn get_syntax(media_type: MediaType) -> Syntax {
   }
 }
 
+/// Gets the default `EsConfig` used by `deno_ast` for the provided options.
 pub fn get_es_config(jsx: bool) -> EsConfig {
   EsConfig {
     class_private_methods: true,
@@ -150,6 +186,7 @@ pub fn get_es_config(jsx: bool) -> EsConfig {
   }
 }
 
+/// Gets the default `TsConfig` used by `deno_ast` for the provided options.
 pub fn get_ts_config(tsx: bool, dts: bool) -> TsConfig {
   TsConfig {
     decorators: true,

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -52,7 +52,7 @@ pub fn parse_program(params: ParseParams) -> Result<ParsedSource, Diagnostic> {
 /// ```
 /// deno_ast::parse_program_with_post_process(
 ///  deno_ast::ParseParams {
-///    specifier: "file:///my-file.ts".to_string(),
+///    specifier: "file:///my_file.ts".to_string(),
 ///    media_type: deno_ast::MediaType::TypeScript,
 ///    source: deno_ast::SourceTextInfo::from_string("".to_string()),
 ///    capture_tokens: true,

--- a/src/text_info.rs
+++ b/src/text_info.rs
@@ -8,10 +8,13 @@ use super::types::LineAndColumnIndex;
 use crate::swc::common::BytePos;
 use crate::swc::common::Span;
 
-/// Stores the source text along with other data such
-/// as where all the lines occur in the text.
+/// Stores the source text along with other data such as where all the lines
+/// occur in the text.
+///
+/// Note: This struct is cheap to clone.
 #[derive(Clone)]
 pub struct SourceTextInfo {
+  // keep this struct cheap to clone
   start_pos: BytePos,
   text: Arc<String>,
   text_lines: Arc<TextLines>,

--- a/src/text_info.rs
+++ b/src/text_info.rs
@@ -8,6 +8,8 @@ use super::types::LineAndColumnIndex;
 use crate::swc::common::BytePos;
 use crate::swc::common::Span;
 
+/// Stores the source text along with other data such
+/// as where all the lines occur in the text.
 #[derive(Clone)]
 pub struct SourceTextInfo {
   start_pos: BytePos,
@@ -16,7 +18,18 @@ pub struct SourceTextInfo {
 }
 
 impl SourceTextInfo {
-  pub fn new(start_pos: BytePos, text: Arc<String>) -> Self {
+  /// Creates a new `SourceTextInfo` from the provided source text.
+  pub fn new(text: Arc<String>) -> Self {
+    Self::new_with_pos(BytePos(0), text)
+  }
+
+  /// Creates a new `SourceTextInfo` from the provided byte position
+  /// and source text.
+  ///
+  /// Generally, most files will have a start position of `BytePos(0)`
+  /// and when in doubt provide that, but SWC will not necessarily
+  /// start files with `BytePos(0)` when bundling.
+  pub fn new_with_pos(start_pos: BytePos, text: Arc<String>) -> Self {
     // The BOM should be stripped before it gets passed here
     // because it's a text encoding concern that should be
     // stripped when the file is read.
@@ -34,15 +47,18 @@ impl SourceTextInfo {
       text
     };
 
-    Self::with_indent_width(start_pos, text, 2)
+    Self::new_with_indent_width(start_pos, text, 2)
   }
 
-  pub fn from_string(mut text: String) -> Self {
-    strip_bom_mut(&mut text);
-    Self::new(BytePos(0), Arc::new(text))
-  }
-
-  pub fn with_indent_width(
+  /// Creates a new `SourceTextInfo` from the provided start position,
+  /// source text, and indentation width.
+  ///
+  /// The indentation width determines the number of columns to use
+  /// when going over a tab character. For example, an indent width
+  /// of 2 will mean each tab character will represent 2 columns.
+  /// The default indentation width used in the other methods is `2`
+  /// to match the default indentation used by `deno fmt`.
+  pub fn new_with_indent_width(
     start_pos: BytePos,
     text: Arc<String>,
     indent_width: usize,
@@ -54,14 +70,26 @@ impl SourceTextInfo {
     }
   }
 
+  /// Creates a new `SourceTextInfo` from the provided source text.
+  ///
+  /// Generally, prefer using `SourceTextInfo::new` to provide a
+  /// string already in an `std::sync::Arc`.
+  pub fn from_string(mut text: String) -> Self {
+    strip_bom_mut(&mut text);
+    Self::new(Arc::new(text))
+  }
+
+  /// Gets the source text.
   pub fn text(&self) -> Arc<String> {
     self.text.clone()
   }
 
+  /// Gets a reference to the source text.
   pub fn text_str(&self) -> &str {
     self.text.as_str()
   }
 
+  /// Gets the range—start and end byte position—of the source text.
   pub fn span(&self) -> Span {
     let start = self.start_pos;
     Span::new(
@@ -71,10 +99,15 @@ impl SourceTextInfo {
     )
   }
 
+  /// Gets the number of lines in the source text.
   pub fn lines_count(&self) -> usize {
     self.text_lines.lines_count()
   }
 
+  /// Gets the 0-indexed line index at the provided byte position.
+  ///
+  /// Note that this will panic when providing a byte position outside
+  /// the range of the source text.
   pub fn line_index(&self, pos: BytePos) -> usize {
     self.assert_pos(pos);
     self
@@ -82,16 +115,28 @@ impl SourceTextInfo {
       .line_index(self.get_relative_index_from_pos(pos))
   }
 
+  /// Gets the line start byte position of the provided 0-indexed line index.
+  ///
+  /// Note that this will panic if providing a line index outside the
+  /// bounds of the number of lines.
   pub fn line_start(&self, line_index: usize) -> BytePos {
     self.assert_line_index(line_index);
     self.get_pos_from_relative_index(self.text_lines.line_start(line_index))
   }
 
+  /// Gets the line end byte position of the provided 0-indexed line index.
+  ///
+  /// Note that this will panic if providing a line index outside the
+  /// bounds of the number of lines.
   pub fn line_end(&self, line_index: usize) -> BytePos {
     self.assert_line_index(line_index);
     self.get_pos_from_relative_index(self.text_lines.line_end(line_index))
   }
 
+  /// Gets the 0-indexed line and column index of the provided byte position.
+  ///
+  /// Note that this will panic when providing a byte position outside
+  /// the range of the source text.
   pub fn line_and_column_index(&self, pos: BytePos) -> LineAndColumnIndex {
     self.assert_pos(pos);
     self
@@ -99,6 +144,11 @@ impl SourceTextInfo {
       .line_and_column_index(self.get_relative_index_from_pos(pos))
   }
 
+  /// Gets the 1-indexed line and column index of the provided byte position
+  /// taking into account the default indentation width.
+  ///
+  /// Note that this will panic when providing a byte position outside
+  /// the range of the source text.
   pub fn line_and_column_display(&self, pos: BytePos) -> LineAndColumnDisplay {
     self.assert_pos(pos);
     self
@@ -106,6 +156,11 @@ impl SourceTextInfo {
       .line_and_column_display(self.get_relative_index_from_pos(pos))
   }
 
+  /// Gets the 1-indexed line and column index of the provided byte position
+  /// with a custom indentation width.
+  ///
+  /// Note that this will panic when providing a byte position outside
+  /// the range of the source text.
   pub fn line_and_column_display_with_indent_width(
     &self,
     pos: BytePos,
@@ -118,6 +173,11 @@ impl SourceTextInfo {
     )
   }
 
+  /// Gets a reference to the text slice of the line at the provided
+  /// 0-based index.
+  ///
+  /// Note that this will panic if providing a line index outside the
+  /// bounds of the number of lines.
   pub fn line_text(&self, line_index: usize) -> &str {
     let line_start = self.line_start(line_index).0 as usize;
     let line_end = self.line_end(line_index).0 as usize;
@@ -227,7 +287,7 @@ mod test {
     let text = "12\n3\r\nβ\n5";
     for i in 0..10 {
       let source_file =
-        SourceTextInfo::new(BytePos(i), Arc::new(text.to_string()));
+        SourceTextInfo::new_with_pos(BytePos(i), Arc::new(text.to_string()));
       assert_pos_line_and_col(&source_file, i, 0, 0); // 1
       assert_pos_line_and_col(&source_file, 1 + i, 0, 1); // 2
       assert_pos_line_and_col(&source_file, 2 + i, 0, 2); // \n
@@ -262,7 +322,7 @@ mod test {
     expected = "The provided position 0 was less than the start position 1."
   )]
   fn line_and_column_index_panic_less_than() {
-    let info = SourceTextInfo::new(BytePos(1), Arc::new("test".to_string()));
+    let info = SourceTextInfo::new_with_pos(BytePos(1), Arc::new("test".to_string()));
     info.line_and_column_index(BytePos(0));
   }
 
@@ -271,7 +331,7 @@ mod test {
     expected = "The provided position 6 was greater than the end position 5."
   )]
   fn line_and_column_index_panic_greater_than() {
-    let info = SourceTextInfo::new(BytePos(1), Arc::new("test".to_string()));
+    let info = SourceTextInfo::new_with_pos(BytePos(1), Arc::new("test".to_string()));
     info.line_and_column_index(BytePos(6));
   }
 
@@ -280,7 +340,7 @@ mod test {
     let text = "12\n3\r\n4\n5";
     for i in 0..10 {
       let source_file =
-        SourceTextInfo::new(BytePos(i), Arc::new(text.to_string()));
+        SourceTextInfo::new_with_pos(BytePos(i), Arc::new(text.to_string()));
       assert_line_start(&source_file, 0, BytePos(i));
       assert_line_start(&source_file, 1, BytePos(3 + i));
       assert_line_start(&source_file, 2, BytePos(6 + i));
@@ -301,7 +361,7 @@ mod test {
     expected = "The specified line index 1 was greater or equal to the number of lines of 1."
   )]
   fn line_start_equal_number_lines() {
-    let info = SourceTextInfo::new(BytePos(1), Arc::new("test".to_string()));
+    let info = SourceTextInfo::new_with_pos(BytePos(1), Arc::new("test".to_string()));
     info.line_start(1);
   }
 
@@ -310,7 +370,7 @@ mod test {
     let text = "12\n3\r\n4\n5";
     for i in 0..10 {
       let source_file =
-        SourceTextInfo::new(BytePos(i), Arc::new(text.to_string()));
+        SourceTextInfo::new_with_pos(BytePos(i), Arc::new(text.to_string()));
       assert_line_end(&source_file, 0, BytePos(2 + i));
       assert_line_end(&source_file, 1, BytePos(4 + i));
       assert_line_end(&source_file, 2, BytePos(7 + i));
@@ -331,7 +391,7 @@ mod test {
     expected = "The specified line index 1 was greater or equal to the number of lines of 1."
   )]
   fn line_end_equal_number_lines() {
-    let info = SourceTextInfo::new(BytePos(1), Arc::new("test".to_string()));
+    let info = SourceTextInfo::new_with_pos(BytePos(1), Arc::new("test".to_string()));
     info.line_end(1);
   }
 

--- a/src/text_info.rs
+++ b/src/text_info.rs
@@ -325,7 +325,8 @@ mod test {
     expected = "The provided position 0 was less than the start position 1."
   )]
   fn line_and_column_index_panic_less_than() {
-    let info = SourceTextInfo::new_with_pos(BytePos(1), Arc::new("test".to_string()));
+    let info =
+      SourceTextInfo::new_with_pos(BytePos(1), Arc::new("test".to_string()));
     info.line_and_column_index(BytePos(0));
   }
 
@@ -334,7 +335,8 @@ mod test {
     expected = "The provided position 6 was greater than the end position 5."
   )]
   fn line_and_column_index_panic_greater_than() {
-    let info = SourceTextInfo::new_with_pos(BytePos(1), Arc::new("test".to_string()));
+    let info =
+      SourceTextInfo::new_with_pos(BytePos(1), Arc::new("test".to_string()));
     info.line_and_column_index(BytePos(6));
   }
 
@@ -364,7 +366,8 @@ mod test {
     expected = "The specified line index 1 was greater or equal to the number of lines of 1."
   )]
   fn line_start_equal_number_lines() {
-    let info = SourceTextInfo::new_with_pos(BytePos(1), Arc::new("test".to_string()));
+    let info =
+      SourceTextInfo::new_with_pos(BytePos(1), Arc::new("test".to_string()));
     info.line_start(1);
   }
 
@@ -394,7 +397,8 @@ mod test {
     expected = "The specified line index 1 was greater or equal to the number of lines of 1."
   )]
   fn line_end_equal_number_lines() {
-    let info = SourceTextInfo::new_with_pos(BytePos(1), Arc::new("test".to_string()));
+    let info =
+      SourceTextInfo::new_with_pos(BytePos(1), Arc::new("test".to_string()));
     info.line_end(1);
   }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,13 +2,21 @@
 
 use std::fmt;
 
-pub type LineAndColumnDisplay = text_lines::LineAndColumnDisplay;
+/// A 0-indexed line and column type.
 pub type LineAndColumnIndex = text_lines::LineAndColumnIndex;
 
+/// A 1-indexed line and column type which should be used for
+/// display purposes only (ex. in diagnostics).
+pub type LineAndColumnDisplay = text_lines::LineAndColumnDisplay;
+
+/// Parsing diagnostic.
 #[derive(Debug, Clone)]
 pub struct Diagnostic {
+  /// Specifier of the source the diagnostic occurred in.
   pub specifier: String,
+  /// 1-indexed display position the diagnostic occurred at.
   pub display_position: LineAndColumnDisplay,
+  /// Message text of the diagnostic.
   pub message: String,
 }
 


### PR DESCRIPTION
Adds the initial documentation to deno_ast. Will follow up with another commit that adds more tests and implements the CI.

Part of #2.