### PR TITLE
feat: Make MediaType::from_path public

### DIFF
--- a/src/media_type.rs
+++ b/src/media_type.rs
@@ -105,7 +105,7 @@ impl MediaType {
     }
   }
 
-  fn from_path(path: &Path) -> Self {
+  pub fn from_path(path: &Path) -> Self {
     match path.extension() {
       None => match path.file_name() {
         None => Self::Unknown,


### PR DESCRIPTION
I need it in `deno_lint`