### PR TITLE
feat: ability to parse with scope analysis applied

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ description = "Source text parsing, lexing, and AST related functionality for De
 [features]
 bundler = ["swc_bundler"]
 codegen = ["swc_ecmascript/codegen"]
+compat = ["swc_ecmascript/compat"]
 dep_graph = ["swc_ecmascript/dep_graph"]
 minifier = ["swc_ecmascript/minifier"]
 module_specifier = ["data-url", "url"]

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ let parsed_source = parse_module(ParseParams {
   source: source_text_info,
   capture_tokens: true,
   maybe_syntax: None,
+  scope_analysis: false,
 }).expect("should parse");
 
 // returns the comments

--- a/src/comments.rs
+++ b/src/comments.rs
@@ -188,6 +188,7 @@ mod test {
       media_type: MediaType::TypeScript,
       capture_tokens: false,
       maybe_syntax: None,
+      scope_analysis: false,
     })
     .expect("expects a module");
     module.comments().as_single_threaded()

--- a/src/parsed_source.rs
+++ b/src/parsed_source.rs
@@ -15,10 +15,6 @@ use crate::swc::parser::token::TokenAndSpan;
 use crate::MediaType;
 use crate::SourceTextInfo;
 
-pub(crate) struct ScopeAnalysisInfo {
-  pub top_level_context: SyntaxContext,
-}
-
 /// A parsed source containing an AST, comments, and possibly tokens.
 ///
 /// Note: This struct is cheap to clone.
@@ -31,7 +27,7 @@ pub struct ParsedSource {
   comments: MultiThreadedComments,
   program: Arc<Program>,
   tokens: Option<Arc<Vec<TokenAndSpan>>>,
-  scope_analysis_info: Option<Arc<ScopeAnalysisInfo>>,
+  top_level_context: Option<SyntaxContext>,
 }
 
 impl ParsedSource {
@@ -42,7 +38,7 @@ impl ParsedSource {
     comments: MultiThreadedComments,
     program: Arc<Program>,
     tokens: Option<Arc<Vec<TokenAndSpan>>>,
-    scope_analysis_info: Option<Arc<ScopeAnalysisInfo>>,
+    top_level_context: Option<SyntaxContext>,
   ) -> Self {
     ParsedSource {
       specifier,
@@ -51,7 +47,7 @@ impl ParsedSource {
       comments,
       program,
       tokens,
-      scope_analysis_info,
+      top_level_context,
     }
   }
 
@@ -128,8 +124,7 @@ impl ParsedSource {
   ///
   /// This will panic if the source was not parsed with scope analysis.
   pub fn top_level_context(&self) -> SyntaxContext {
-    self.scope_analysis_info.as_ref().expect("Could not get top level context because the source was not parsed with scope analysis.")
-      .top_level_context
+    self.top_level_context.expect("Could not get top level context because the source was not parsed with scope analysis.")
   }
 }
 

--- a/src/parsed_source.rs
+++ b/src/parsed_source.rs
@@ -9,8 +9,6 @@ use crate::swc::ast::Program;
 use crate::swc::ast::Script;
 use crate::swc::common::comments::Comment;
 use crate::swc::common::comments::Comments;
-use crate::swc::common::Globals;
-use crate::swc::common::Mark;
 use crate::swc::common::Spanned;
 use crate::swc::common::SyntaxContext;
 use crate::swc::parser::token::TokenAndSpan;
@@ -18,8 +16,6 @@ use crate::MediaType;
 use crate::SourceTextInfo;
 
 pub(crate) struct ScopeAnalysisInfo {
-  pub globals: Globals,
-  pub top_level_mark: Mark,
   pub top_level_context: SyntaxContext,
 }
 
@@ -126,22 +122,6 @@ impl ParsedSource {
       .tokens
       .as_ref()
       .expect("Tokens not found because they were not captured during parsing.")
-  }
-
-  /// Gets the swc hygiene data used when parsing with scope analysis.
-  ///
-  /// This will panic if the source was not parsed with scope analysis.
-  pub fn globals(&self) -> &Globals {
-    &self.scope_analysis_info.as_ref().expect("Could not get globals because the source was not parsed with scope analysis.")
-      .globals
-  }
-
-  /// Gets the top level mark used when parsing with scope analysis.
-  ///
-  /// This will panic if the source was not parsed with scope analysis.
-  pub fn top_level_mark(&self) -> Mark {
-    self.scope_analysis_info.as_ref().expect("Could not get top level mark because the source was not parsed with scope analysis.")
-      .top_level_mark
   }
 
   /// Gets the top level context used when parsing with scope analysis.

--- a/src/parsed_source.rs
+++ b/src/parsed_source.rs
@@ -9,10 +9,19 @@ use crate::swc::ast::Program;
 use crate::swc::ast::Script;
 use crate::swc::common::comments::Comment;
 use crate::swc::common::comments::Comments;
+use crate::swc::common::Globals;
+use crate::swc::common::Mark;
 use crate::swc::common::Spanned;
+use crate::swc::common::SyntaxContext;
 use crate::swc::parser::token::TokenAndSpan;
 use crate::MediaType;
 use crate::SourceTextInfo;
+
+pub(crate) struct ScopeAnalysisInfo {
+  pub globals: Globals,
+  pub top_level_mark: Mark,
+  pub top_level_context: SyntaxContext,
+}
 
 /// A parsed source containing an AST, comments, and possibly tokens.
 ///
@@ -26,16 +35,18 @@ pub struct ParsedSource {
   comments: MultiThreadedComments,
   program: Arc<Program>,
   tokens: Option<Arc<Vec<TokenAndSpan>>>,
+  scope_analysis_info: Option<Arc<ScopeAnalysisInfo>>,
 }
 
 impl ParsedSource {
-  pub fn new(
+  pub(crate) fn new(
     specifier: String,
     media_type: MediaType,
     source: SourceTextInfo,
     comments: MultiThreadedComments,
     program: Arc<Program>,
     tokens: Option<Arc<Vec<TokenAndSpan>>>,
+    scope_analysis_info: Option<Arc<ScopeAnalysisInfo>>,
   ) -> Self {
     ParsedSource {
       specifier,
@@ -44,6 +55,7 @@ impl ParsedSource {
       comments,
       program,
       tokens,
+      scope_analysis_info,
     }
   }
 
@@ -107,11 +119,37 @@ impl ParsedSource {
   }
 
   /// Gets the tokens found in the source file.
+  ///
+  /// This will panic if tokens were not captured during parsing.
   pub fn tokens(&self) -> &[TokenAndSpan] {
     self
       .tokens
       .as_ref()
       .expect("Tokens not found because they were not captured during parsing.")
+  }
+
+  /// Gets the swc hygiene data used when parsing with scope analysis.
+  ///
+  /// This will panic if the source was not parsed with scope analysis.
+  pub fn globals(&self) -> &Globals {
+    &self.scope_analysis_info.as_ref().expect("Could not get globals because the source was not parsed with scope analysis.")
+      .globals
+  }
+
+  /// Gets the top level mark used when parsing with scope analysis.
+  ///
+  /// This will panic if the source was not parsed with scope analysis.
+  pub fn top_level_mark(&self) -> Mark {
+    self.scope_analysis_info.as_ref().expect("Could not get top level mark because the source was not parsed with scope analysis.")
+      .top_level_mark
+  }
+
+  /// Gets the top level context used when parsing with scope analysis.
+  ///
+  /// This will panic if the source was not parsed with scope analysis.
+  pub fn top_level_context(&self) -> SyntaxContext {
+    self.scope_analysis_info.as_ref().expect("Could not get top level context because the source was not parsed with scope analysis.")
+      .top_level_context
   }
 }
 
@@ -171,6 +209,7 @@ mod test {
       media_type: MediaType::JavaScript,
       capture_tokens: true,
       maybe_syntax: None,
+      scope_analysis: false,
     })
     .expect("should parse");
 

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -137,7 +137,7 @@ fn parse(
       })?;
   let program = post_process(program);
 
-  let (program, scope_analysis_info) = if params.scope_analysis {
+  let (program, top_level_context) = if params.scope_analysis {
     #[cfg(feature = "transforms")]
     {
       use crate::swc::common::Globals;
@@ -145,7 +145,6 @@ fn parse(
       use crate::swc::common::SyntaxContext;
       use crate::swc::transforms::resolver::ts_resolver;
       use crate::swc::visit::FoldWith;
-      use crate::ScopeAnalysisInfo;
 
       let globals = Globals::new();
       crate::swc::common::GLOBALS.set(&globals, || {
@@ -155,10 +154,7 @@ fn parse(
         let top_level_context =
           SyntaxContext::empty().apply_mark(top_level_mark);
 
-        (
-          program,
-          Some(Arc::new(ScopeAnalysisInfo { top_level_context })),
-        )
+        (program, Some(top_level_context))
       })
     }
     #[cfg(not(feature = "transforms"))]
@@ -174,7 +170,7 @@ fn parse(
     MultiThreadedComments::from_single_threaded(comments),
     Arc::new(program),
     tokens.map(Arc::new),
-    scope_analysis_info,
+    top_level_context,
   ))
 }
 

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -3,7 +3,9 @@
 use std::sync::Arc;
 
 use crate::comments::MultiThreadedComments;
+use crate::swc::ast::Module;
 use crate::swc::ast::Program;
+use crate::swc::ast::Script;
 use crate::swc::common::comments::SingleThreadedComments;
 use crate::swc::common::input::StringInput;
 use crate::swc::common::Spanned;
@@ -31,6 +33,8 @@ pub struct ParseParams {
   pub media_type: MediaType,
   /// Whether to capture tokens or not.
   pub capture_tokens: bool,
+  /// Whether to apply swc's scope analysis.
+  pub scope_analysis: bool,
   /// Syntax to use when parsing.
   ///
   /// `deno_ast` will get a default `Syntax` to use based on the
@@ -57,6 +61,7 @@ pub fn parse_program(params: ParseParams) -> Result<ParsedSource, Diagnostic> {
 ///    source: deno_ast::SourceTextInfo::from_string("".to_string()),
 ///    capture_tokens: true,
 ///    maybe_syntax: None,
+///    scope_analysis: false,
 ///  },
 ///  |program| {
 ///    // do something with the program here before it gets stored
@@ -76,9 +81,31 @@ pub fn parse_module(params: ParseParams) -> Result<ParsedSource, Diagnostic> {
   parse(params, ParseMode::Module, |p| p)
 }
 
+/// Parses a module with post processing (see docs on `parse_program_with_post_process`).
+pub fn parse_module_with_post_process(
+  params: ParseParams,
+  post_process: impl FnOnce(Module) -> Module,
+) -> Result<ParsedSource, Diagnostic> {
+  parse(params, ParseMode::Module, |program| match program {
+    Program::Module(module) => Program::Module(post_process(module)),
+    Program::Script(_) => unreachable!(),
+  })
+}
+
 /// Parses the provided information to a script.
 pub fn parse_script(params: ParseParams) -> Result<ParsedSource, Diagnostic> {
   parse(params, ParseMode::Script, |p| p)
+}
+
+/// Parses a script with post processing (see docs on `parse_program_with_post_process`).
+pub fn parse_script_with_post_process(
+  params: ParseParams,
+  post_process: impl FnOnce(Script) -> Script,
+) -> Result<ParsedSource, Diagnostic> {
+  parse(params, ParseMode::Script, |program| match program {
+    Program::Module(_) => unreachable!(),
+    Program::Script(script) => Program::Script(post_process(script)),
+  })
 }
 
 enum ParseMode {
@@ -110,6 +137,40 @@ fn parse(
       })?;
   let program = post_process(program);
 
+  let (program, scope_analysis_info) = if params.scope_analysis {
+    #[cfg(feature = "transforms")]
+    {
+      use crate::swc::common::Globals;
+      use crate::swc::common::Mark;
+      use crate::swc::common::SyntaxContext;
+      use crate::swc::transforms::resolver::ts_resolver;
+      use crate::swc::visit::FoldWith;
+      use crate::ScopeAnalysisInfo;
+
+      let globals = Globals::new();
+      let (program, top_level_mark, top_level_context) =
+        crate::swc::common::GLOBALS.set(&globals, || {
+          // This is used to apply proper "syntax context" to all AST elements.
+          let top_level_mark = Mark::fresh(Mark::root());
+          let program = program.fold_with(&mut ts_resolver(top_level_mark));
+          let top_level_context =
+            SyntaxContext::empty().apply_mark(top_level_mark);
+
+          (program, top_level_mark, top_level_context)
+        });
+      let scope_analysis_info = ScopeAnalysisInfo {
+        globals,
+        top_level_mark,
+        top_level_context,
+      };
+      (program, Some(Arc::new(scope_analysis_info)))
+    }
+    #[cfg(not(feature = "transforms"))]
+    panic!("Cannot parse with scope analysis. Please enable the 'transforms' feature.")
+  } else {
+    (program, None)
+  };
+
   Ok(ParsedSource::new(
     specifier,
     params.media_type.to_owned(),
@@ -117,6 +178,7 @@ fn parse(
     MultiThreadedComments::from_single_threaded(comments),
     Arc::new(program),
     tokens.map(Arc::new),
+    scope_analysis_info,
   ))
 }
 
@@ -216,6 +278,7 @@ mod test {
       media_type: MediaType::JavaScript,
       capture_tokens: true,
       maybe_syntax: None,
+      scope_analysis: false,
     })
     .expect("should parse");
     assert_eq!(program.specifier(), "my_file.js");
@@ -239,6 +302,7 @@ mod test {
       media_type: MediaType::JavaScript,
       capture_tokens: true,
       maybe_syntax: None,
+      scope_analysis: false,
     })
     .expect("should parse");
     assert!(matches!(
@@ -258,6 +322,7 @@ mod test {
       media_type: MediaType::JavaScript,
       capture_tokens: false,
       maybe_syntax: None,
+      scope_analysis: false,
     })
     .expect("should parse");
     program.tokens();
@@ -271,6 +336,7 @@ mod test {
       media_type: MediaType::JavaScript,
       capture_tokens: true,
       maybe_syntax: None,
+      scope_analysis: false,
     })
     .err()
     .unwrap();
@@ -285,5 +351,84 @@ mod test {
         message: "Expected ';', '}' or <eof>".to_string(),
       }
     )
+  }
+
+  #[test]
+  #[should_panic(
+    expected = "Could not get top level mark because the source was not parsed with scope analysis."
+  )]
+  fn should_panic_when_getting_top_level_mark_and_scope_analysis_false() {
+    get_scope_analysis_false_parsed_source().top_level_mark();
+  }
+
+  #[test]
+  #[should_panic(
+    expected = "Could not get globals because the source was not parsed with scope analysis."
+  )]
+  fn should_panic_when_getting_globals_and_scope_analysis_false() {
+    get_scope_analysis_false_parsed_source().globals();
+  }
+
+  #[test]
+  #[should_panic(
+    expected = "Could not get top level context because the source was not parsed with scope analysis."
+  )]
+  fn should_panic_when_getting_top_level_context_and_scope_analysis_false() {
+    get_scope_analysis_false_parsed_source().top_level_context();
+  }
+
+  fn get_scope_analysis_false_parsed_source() -> ParsedSource {
+    parse_module(ParseParams {
+      specifier: "my_file.js".to_string(),
+      source: SourceTextInfo::from_string("// 1\n1 + 1\n// 2".to_string()),
+      media_type: MediaType::JavaScript,
+      capture_tokens: false,
+      maybe_syntax: None,
+      scope_analysis: false,
+    })
+    .expect("should parse")
+  }
+
+  #[cfg(all(feature = "view", feature = "transforms"))]
+  #[test]
+  fn should_do_scope_analysis() {
+    let parsed_source = parse_module(ParseParams {
+      specifier: "my_file.js".to_string(),
+      source: SourceTextInfo::from_string(
+        "export function test() { const test = 2; test; } test()".to_string(),
+      ),
+      media_type: MediaType::JavaScript,
+      capture_tokens: true,
+      maybe_syntax: None,
+      scope_analysis: true,
+    })
+    .expect("should parse");
+
+    parsed_source.with_view(|view| {
+      use crate::swc::utils::ident::IdentLike;
+      use crate::view::*;
+
+      let func_decl = view.children()[0]
+        .expect::<ExportDecl>()
+        .decl
+        .expect::<FnDecl>();
+      let func_decl_inner_expr = func_decl.function.body.unwrap().stmts[1]
+        .expect::<ExprStmt>()
+        .expr
+        .expect::<Ident>();
+      let call_expr = view.children()[1]
+        .expect::<ExprStmt>()
+        .expr
+        .expect::<CallExpr>();
+      let call_expr_id = call_expr.callee.expect::<Ident>();
+
+      // these should be the same identifier
+      assert_eq!(func_decl.ident.inner.to_id(), call_expr_id.inner.to_id());
+      // but these shouldn't be
+      assert_ne!(
+        func_decl.ident.inner.to_id(),
+        func_decl_inner_expr.inner.to_id()
+      );
+    });
   }
 }

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -148,22 +148,18 @@ fn parse(
       use crate::ScopeAnalysisInfo;
 
       let globals = Globals::new();
-      let (program, top_level_mark, top_level_context) =
-        crate::swc::common::GLOBALS.set(&globals, || {
-          // This is used to apply proper "syntax context" to all AST elements.
-          let top_level_mark = Mark::fresh(Mark::root());
-          let program = program.fold_with(&mut ts_resolver(top_level_mark));
-          let top_level_context =
-            SyntaxContext::empty().apply_mark(top_level_mark);
+      crate::swc::common::GLOBALS.set(&globals, || {
+        // This is used to apply proper "syntax context" to all AST elements.
+        let top_level_mark = Mark::fresh(Mark::root());
+        let program = program.fold_with(&mut ts_resolver(top_level_mark));
+        let top_level_context =
+          SyntaxContext::empty().apply_mark(top_level_mark);
 
-          (program, top_level_mark, top_level_context)
-        });
-      let scope_analysis_info = ScopeAnalysisInfo {
-        globals,
-        top_level_mark,
-        top_level_context,
-      };
-      (program, Some(Arc::new(scope_analysis_info)))
+        (
+          program,
+          Some(Arc::new(ScopeAnalysisInfo { top_level_context })),
+        )
+      })
     }
     #[cfg(not(feature = "transforms"))]
     panic!("Cannot parse with scope analysis. Please enable the 'transforms' feature.")
@@ -351,22 +347,6 @@ mod test {
         message: "Expected ';', '}' or <eof>".to_string(),
       }
     )
-  }
-
-  #[test]
-  #[should_panic(
-    expected = "Could not get top level mark because the source was not parsed with scope analysis."
-  )]
-  fn should_panic_when_getting_top_level_mark_and_scope_analysis_false() {
-    get_scope_analysis_false_parsed_source().top_level_mark();
-  }
-
-  #[test]
-  #[should_panic(
-    expected = "Could not get globals because the source was not parsed with scope analysis."
-  )]
-  fn should_panic_when_getting_globals_and_scope_analysis_false() {
-    get_scope_analysis_false_parsed_source().globals();
   }
 
   #[test]


### PR DESCRIPTION
Closes #8.

This will simplify deno_lint a little bit and allow us to re-use the cached source files for linting in the LSP again.