### PR TITLE
fix: MediaType from content type with conflicting extension

### DIFF
--- a/src/media_type.rs
+++ b/src/media_type.rs
@@ -290,9 +290,7 @@ fn map_js_like_extension(
       //
       // This handles situations where the file is transpiled on the server and
       // is explicitly providing a media type.
-      Some("ts") => {
-        map_typescript_like(&path, default, MediaType::Dts)
-      }
+      Some("ts") => map_typescript_like(&path, default, MediaType::Dts),
       Some("mts") => {
         let base_type = if default == MediaType::JavaScript {
           MediaType::Mjs
@@ -549,16 +547,8 @@ mod tests {
         "text/plain",
         MediaType::TypeScript,
       ),
-      (
-        "https://deno.land/x/mod.mts",
-        "text/plain",
-        MediaType::Mts,
-      ),
-      (
-        "https://deno.land/x/mod.cts",
-        "text/plain",
-        MediaType::Cts,
-      ),
+      ("https://deno.land/x/mod.mts", "text/plain", MediaType::Mts),
+      ("https://deno.land/x/mod.cts", "text/plain", MediaType::Cts),
       (
         "https://deno.land/x/mod.js",
         "text/plain",


### PR DESCRIPTION
@dsherret I thought about the issue you pointed out, and I think I had it wrong, in that if we have a content type of `application/javascript` we should respect that, assuming the remote did the transpile already and is clearly overriding automatic content types, except for situations where it would be a type only file anyways (`.d.ts`, `.d.mts`, `.d.cts`) where clearly something is "wrong" since those don't emit.

I don't know any specific behaviours in the wild, but best to keep the behaviour and document it. Based on that, I also aligned it so that a `application/javascript` with a `.mts` file becomes `MediaType::Mjs` and `application/javascript` with `.cts` file becomes `MediaType::Cjs`.

@bartlomieju @ry while I still have my reservations about it, this whole thing we are having to do for TypeScript 4.5 should also allow us to identify and handle CJS files through the module "pipeline". I guess if we are going to do it, I would rather do it properly. 😒 