### PR TITLE
refactor: remove compat feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ description = "Source text parsing, lexing, and AST related functionality for De
 [features]
 bundler = ["swc_bundler"]
 codegen = ["swc_ecmascript/codegen"]
-compat = ["swc_ecmascript/compat"]
 dep_graph = ["swc_ecmascript/dep_graph"]
 minifier = ["swc_ecmascript/minifier"]
 module_specifier = ["data-url", "url"]


### PR DESCRIPTION
We don't use it and there was just a breaking change in it in a patch.