### PR TITLE
feat: add method to `MediaType` for telling if declaration file media type

### DIFF
--- a/src/media_type.rs
+++ b/src/media_type.rs
@@ -84,6 +84,26 @@ impl MediaType {
     }
   }
 
+  /// Gets if this media type is for a TypeScript declaration file.
+  pub fn is_declaration(&self) -> bool {
+    match self {
+      Self::Dts | Self::Dmts | Self::Dcts => true,
+      Self::JavaScript
+      | Self::Jsx
+      | Self::Mjs
+      | Self::Cjs
+      | Self::TypeScript
+      | Self::Mts
+      | Self::Cts
+      | Self::Tsx
+      | Self::Json
+      | Self::Wasm
+      | Self::TsBuildInfo
+      | Self::SourceMap
+      | Self::Unknown => false,
+    }
+  }
+
   #[cfg(feature = "module_specifier")]
   pub fn from_content_type<S: AsRef<str>>(
     specifier: &ModuleSpecifier,


### PR DESCRIPTION
Let me know if you have a suggestion for a better name.