### PR TITLE
fix: add text/jscript to content type matchers

### DIFF
--- a/src/media_type.rs
+++ b/src/media_type.rs
@@ -129,6 +129,7 @@ impl MediaType {
       | "application/node" => {
         map_js_like_extension(specifier, Self::JavaScript)
       }
+      "text/jscript" => map_js_like_extension(specifier, Self::Jsx),
       "text/jsx" => Self::Jsx,
       "text/tsx" => Self::Tsx,
       "application/json" | "text/json" => Self::Json,
@@ -573,6 +574,11 @@ mod tests {
         "https://deno.land/x/mod.wasm",
         "text/plain",
         MediaType::Wasm,
+      ),
+      (
+        "https://deno.land/x/mod.jsx",
+        "text/jscript",
+        MediaType::Jsx,
       ),
     ];
 


### PR DESCRIPTION
Some mime type registries associate this content type with the .jsx
extension.

Examples:
- https://github.com/samuelneff/MimeTypeMap/blob/master/MimeTypeMap.cs#L273
- https://github.com/abonander/mime_guess/blob/492bece6d9b3253aeeb42d78d9358352d66ee935/src/mime_types.rs#L568
