### PR TITLE
chore(ci): use deno

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,10 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
+      - uses: denoland/setup-deno@v1
+        with:
+          deno-version: 1.x
+
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Cache


### PR DESCRIPTION
Forgot this in the last commit. CI on main will fail.