### PR TITLE
0.13.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   push:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   rust:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "deno_ast"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "anyhow",
  "base64 0.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deno_ast"
-version = "0.13.1"
+version = "0.13.2"
 authors = ["the Deno authors"]
 documentation = "https://docs.rs/deno_ast"
 edition = "2021"


### PR DESCRIPTION
Necessary because of the github actions downtime. I've also added a workflow_dispatch event to allow kicking off a workflow next time this happens.