### PR TITLE
fix: allow specifying a base for source maps

### DIFF
--- a/src/parsed_source.rs
+++ b/src/parsed_source.rs
@@ -118,7 +118,7 @@ impl ParsedSource {
       .inner
       .comments
       .get_leading(self.inner.program.span().lo)
-      .unwrap_or_else(Vec::new)
+      .unwrap_or_default()
   }
 
   /// Gets the tokens found in the source file.

--- a/src/transpiling/mod.rs
+++ b/src/transpiling/mod.rs
@@ -133,11 +133,22 @@ impl EmitOptions {
 #[derive(Debug)]
 pub struct SourceMapConfig {
   pub inline_sources: bool,
+  /// When a base is provided, when mapping source names in the source map, the
+  /// name will be relative to the base.
+  pub maybe_base: Option<ModuleSpecifier>,
 }
 
 impl crate::swc::common::source_map::SourceMapGenConfig for SourceMapConfig {
   fn file_name_to_source(&self, f: &FileName) -> String {
-    f.to_string()
+    match f {
+      FileName::Url(specifier) => self
+        .maybe_base
+        .as_ref()
+        .map(|base| base.make_relative(specifier))
+        .flatten()
+        .unwrap_or_else(|| f.to_string()),
+      _ => f.to_string(),
+    }
   }
 
   fn inline_sources_content(&self, f: &FileName) -> bool {
@@ -162,12 +173,14 @@ impl ParsedSource {
   pub fn transpile(&self, options: &EmitOptions) -> Result<TranspiledSource> {
     let program = (*self.program()).clone();
     let source_map = Rc::new(SourceMap::default());
+    let (file_name, maybe_base) = match ModuleSpecifier::parse(self.specifier())
+    {
+      Ok(specifier) => (FileName::Url(specifier.clone()), Some(specifier)),
+      Err(_) => (FileName::Custom(self.specifier().to_string()), None),
+    };
     let source_map_config = SourceMapConfig {
       inline_sources: options.inline_sources,
-    };
-    let file_name = match ModuleSpecifier::parse(self.specifier()) {
-      Ok(specifier) => FileName::Url(specifier),
-      Err(_) => FileName::Custom(self.specifier().to_string()),
+      maybe_base,
     };
     source_map.new_source_file(file_name, self.source().text().to_string());
     // we need the comments to be mutable, so make it single threaded

--- a/src/transpiling/mod.rs
+++ b/src/transpiling/mod.rs
@@ -144,8 +144,7 @@ impl crate::swc::common::source_map::SourceMapGenConfig for SourceMapConfig {
       FileName::Url(specifier) => self
         .maybe_base
         .as_ref()
-        .map(|base| base.make_relative(specifier))
-        .flatten()
+        .and_then(|base| base.make_relative(specifier))
         .unwrap_or_else(|| f.to_string()),
       _ => f.to_string(),
     }


### PR DESCRIPTION
This fixes the situation where the source map source name is the full name of the file, potentially leaking information in the source map which is undesirable.  This allows specifying a base (as well as specifies the base when doing a transpile) which will make the source file listed as relative of the source.