### PR TITLE
fix: include text changes in panic message

### DIFF
--- a/src/text_changes.rs
+++ b/src/text_changes.rs
@@ -33,15 +33,17 @@ pub fn apply_text_changes(
   let mut last_index = 0;
   let mut final_text = String::new();
 
-  for change in changes {
+  for (i, change) in changes.iter().enumerate() {
     if change.range.start > change.range.end {
       panic!(
-        "Text change had start index {} greater than end index {}.",
-        change.range.start, change.range.end
+        "Text change had start index {} greater than end index {}.\n\n{:?}",
+        change.range.start,
+        change.range.end,
+        &changes[0..i + 1],
       )
     }
     if change.range.start < last_index {
-      panic!("Text changes were overlapping. Past index was {}, but new change had index {}.", last_index, change.range.start);
+      panic!("Text changes were overlapping. Past index was {}, but new change had index {}.\n\n{:?}", last_index, change.range.start, &changes[0..i + 1]);
     } else if change.range.start > last_index && last_index < source.len() {
       final_text.push_str(
         &source[last_index..std::cmp::min(source.len(), change.range.start)],


### PR DESCRIPTION
If this occurs, it's helpful to include the text change information.