### PR TITLE
chore: add publish workflow for doing a release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,11 +47,11 @@ jobs:
       - name: Test
         run: cargo test --all-targets --all-features --release
 
-      - name: Publish on version change
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      - name: Publish
         if: |
           github.repository == 'denoland/deno_ast' &&
-          github.ref == 'refs/heads/main'
-        run: deno run -A --no-check https://raw.githubusercontent.com/denoland/automation/0.7.1/tasks/release_on_crate_version_change.ts --publish
+          startsWith(github.ref, 'refs/tags/')
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          cargo publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,6 @@ on:
       options:
         - patch
         - minor
-        - major
       required: true
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,15 +2,15 @@ name: publish
 
 on:
   workflow_dispatch:
-  inputs:
-    releaseKind:
-      description: 'Kind of release'
-      default: 'minor'
-      type: choice
-      options:
-        - patch
-        - minor
-      required: true
+    inputs:
+      releaseKind:
+        description: 'Kind of release'
+        default: 'minor'
+        type: choice
+        options:
+          - patch
+          - minor
+        required: true
 
 jobs:
   rust:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   rust:
-    name: deno_ast-ubuntu-latest-publish
+    name: publish
     runs-on: ubuntu-latest
     timeout-minutes: 30
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,36 @@
+name: publish
+
+on:
+  workflow_dispatch:
+  inputs:
+    releaseKind:
+      description: 'Kind of release'
+      default: 'minor'
+      type: choice
+      options:
+        - patch
+        - minor
+        - major
+      required: true
+
+jobs:
+  rust:
+    name: deno_ast-ubuntu-latest-publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+
+      - uses: denoland/setup-deno@v1
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.DENOBOT_PAT }}
+          GH_WORKFLOW_ACTOR: ${{ github.actor }}
+        run: |
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          git config user.name "${{ github.actor }}"
+          deno run -A https://raw.githubusercontent.com/denoland/automation/0.14.0/tasks/publish_release.ts --${{github.event.inputs.releaseKind}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: publish
+name: release
 
 on:
   workflow_dispatch:
@@ -14,18 +14,20 @@ on:
 
 jobs:
   rust:
-    name: publish
+    name: release
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.DENOBOT_PAT }}
 
       - uses: denoland/setup-deno@v1
       - uses: dtolnay/rust-toolchain@stable
 
-      - name: Publish
+      - name: Tag and release
         env:
           GITHUB_TOKEN: ${{ secrets.DENOBOT_PAT }}
           GH_WORKFLOW_ACTOR: ${{ github.actor }}

--- a/scripts/deps.ts
+++ b/scripts/deps.ts
@@ -1,3 +1,3 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
-export * from "https://raw.githubusercontent.com/denoland/automation/0.13.0/mod.ts";
+export * from "https://raw.githubusercontent.com/denoland/automation/0.14.0/mod.ts";


### PR DESCRIPTION
This allows us to run a github action workflow to bump the version and do a release.