### PR TITLE
chore: fix release script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,4 +32,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.DENOBOT_PAT }}
           GH_WORKFLOW_ACTOR: ${{ github.actor }}
         run: |
+          git config user.email "denobot@users.noreply.github.com"
+          git config user.name "denobot"
           deno run -A https://raw.githubusercontent.com/denoland/automation/0.14.0/tasks/publish_release.ts --${{github.event.inputs.releaseKind}}


### PR DESCRIPTION
I thought it would pull this in from the PAT somehow, but it doesn't which I guess makes sense.

```
Author identity unknown

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: empty ident name (for <runner@fv-az275-961.go2hi5et44qedpdz5zrtt3gknc.xx.internal.cloudapp.net>) not allowed
error: Uncaught (in promise) Error: Exited with code: 128
        throw new Error(`Exited with code: ${code}`);
```