### PR TITLE
fix: indent diagnostic code two spaces

### DIFF
--- a/src/lexing.rs
+++ b/src/lexing.rs
@@ -2,9 +2,8 @@
 
 use std::rc::Rc;
 
-use swc_atoms::Atom;
-
 use crate::get_syntax;
+use crate::swc::atoms::Atom;
 use crate::swc::common::comments::Comment;
 use crate::swc::common::comments::CommentKind;
 use crate::swc::common::comments::SingleThreadedComments;

--- a/src/transpiling/mod.rs
+++ b/src/transpiling/mod.rs
@@ -829,16 +829,16 @@ for (let i = 0; i < testVariable >> 1; i++) callCount++;
     assert_eq!(get_diagnostic("077"), concat!(
       "Legacy octal literals are not available when targeting ECMAScript 5 and higher ",
       "at https://deno.land/x/mod.ts:1:1\n\n",
-      "077\n",
-      "~~~\n\n",
+      "  077\n",
+      "  ~~~\n\n",
       "Legacy octal escape is not permitted in strict mode at https://deno.land/x/mod.ts:1:1\n\n",
-      "077\n",
-      "~~~",
+      "  077\n",
+      "  ~~~",
     ));
     assert_eq!(get_diagnostic("099"), concat!(
       "Legacy decimal escape is not permitted in strict mode at https://deno.land/x/mod.ts:1:1\n\n",
-      "099\n",
-      "~~~",
+      "  099\n",
+      "  ~~~",
     ));
   }
 
@@ -848,8 +848,8 @@ for (let i = 0; i < testVariable >> 1; i++) callCount++;
       get_diagnostic("function test() {"),
       concat!(
         "Expected '}', got '<eof>' at https://deno.land/x/mod.ts:1:17\n\n",
-        "function test() {\n",
-        "                ~",
+        "  function test() {\n",
+        "                  ~",
       ),
     );
   }
@@ -860,16 +860,16 @@ for (let i = 0; i < testVariable >> 1; i++) callCount++;
       get_diagnostic("null || undefined ?? 'foo';"),
       concat!(
         "Nullish coalescing operator(??) requires parens when mixing with logical operators at https://deno.land/x/mod.ts:1:1\n\n",
-        "null || undefined ?? 'foo';\n",
-        "~~~~~~~~~~~~~~~~~",
+        "  null || undefined ?? 'foo';\n",
+        "  ~~~~~~~~~~~~~~~~~",
       )
     );
     assert_eq!(
       get_diagnostic("null && undefined ?? 'foo';"),
       concat!(
         "Nullish coalescing operator(??) requires parens when mixing with logical operators at https://deno.land/x/mod.ts:1:1\n\n",
-        "null && undefined ?? 'foo';\n",
-        "~~~~~~~~~~~~~~~~~",
+        "  null && undefined ?? 'foo';\n",
+        "  ~~~~~~~~~~~~~~~~~",
       ),
     );
   }

--- a/src/types.rs
+++ b/src/types.rs
@@ -105,6 +105,8 @@ impl fmt::Display for DiagnosticsError {
   }
 }
 
+/// Code in this function was adapted from:
+/// https://github.com/dprint/dprint/blob/a026a1350d27a61ea18207cb31897b18eaab51a1/crates/core/src/formatting/utils/string_utils.rs#L62
 fn get_range_text_highlight(
   source: &SourceTextInfo,
   byte_range: SourceRange,

--- a/src/types.rs
+++ b/src/types.rs
@@ -73,6 +73,11 @@ impl fmt::Display for Diagnostic {
       // tested this out a lot
       std::panic::catch_unwind(|| {
         get_range_text_highlight(&self.source, self.range)
+          .lines()
+          // indent two spaces
+          .map(|l| format!("  {}", l))
+          .collect::<Vec<_>>()
+          .join("\n")
       })
       .unwrap_or_else(|err| {
         format!("Bug. Please report this issue: {:?}", err)


### PR DESCRIPTION
Missed doing this in the last PR (sorry). Noticed in the integration tests in dprint-plugin-typescript.