### PR TITLE
Upgrade swc_ecma_codegen_macros to 0.7.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ swc_atoms = "=0.5.6"
 swc_common = "=0.31.12"
 swc_ecma_ast = { version = "=0.104.5", features = ["serde-impl"] }
 swc_ecma_codegen = { version = "=0.139.17", optional = true }
-swc_ecma_codegen_macros = { version = "=0.7.2", optional = true }
+swc_ecma_codegen_macros = { version = "=0.7.3", optional = true }
 swc_ecma_dep_graph = { version = "=0.106.12", optional = true }
 swc_ecma_loader = { version = "=0.43.14", optional = true }
 swc_ecma_parser = "=0.134.12"


### PR DESCRIPTION
I've been chasing some weird dependency schenanigans in one of my projects that causes a ton of syn 2.0 version mismatch errors. I think it comes down to swc doing the syn 2.0 upgrade in a patch release, but given the complexities of the crate graph here I'm not sure.

However, upgrading deno_ast's dependency to 0.7.3 seems to fix it for me.