### PR TITLE
Implement common traits for `TranspiledSource`

### DIFF
--- a/src/transpiling/mod.rs
+++ b/src/transpiling/mod.rs
@@ -162,6 +162,7 @@ impl crate::swc::common::source_map::SourceMapGenConfig for SourceMapConfig {
 }
 
 /// Source transpiled based on the emit options.
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug)]
 pub struct TranspiledSource {
   /// Transpiled text.
   pub text: String,


### PR DESCRIPTION
I've recently run into the issue that `TranspiledSource` is not `Clone`, requiring me to manually clone each field. Considering that a derive is trivial here, it should hopefully save some headaches in the future.

I've also implemented all other relevant traits from STD, based on https://rust-lang.github.io/api-guidelines/interoperability.html#types-eagerly-implement-common-traits-c-common-traits.