### PR TITLE
feat: precompile JSX to string transform

### DIFF
--- a/src/transpiling/jsx_precompile.rs
+++ b/src/transpiling/jsx_precompile.rs
@@ -178,15 +178,13 @@ fn normalize_dom_attr_name(name: &str) -> String {
     | "vMathematical"
     | "wordSpacing"
     | "writingMode"
-    | "xHeight" => {
-      name
-        .chars()
-        .map(|ch| match ch {
-          'A'..='Z' => format!("-{}", ch.to_lowercase()),
-          _ => ch.to_string(),
-        })
-        .collect()
-    }
+    | "xHeight" => name
+      .chars()
+      .map(|ch| match ch {
+        'A'..='Z' => format!("-{}", ch.to_lowercase()),
+        _ => ch.to_string(),
+      })
+      .collect(),
     _ => {
       // Devs expect attributes in the HTML document to be lowercased.
       name.to_lowercase()

--- a/src/transpiling/jsx_precompile.rs
+++ b/src/transpiling/jsx_precompile.rs
@@ -786,7 +786,6 @@ impl JsxPrecompile {
                   escape_html(string_lit.value.as_ref()).as_str()
                 );
 
-                strings.last_mut().unwrap().push_str("");
                 strings
                   .last_mut()
                   .unwrap()
@@ -859,7 +858,7 @@ impl JsxPrecompile {
     self.templates.push((template_index, static_strs));
 
     let mut args: Vec<ExprOrSpread> =
-      Vec::with_capacity(1 + std::cmp::max(1, dynamic_exprs.len()));
+      Vec::with_capacity(1 + dynamic_exprs.len());
     args.push(ExprOrSpread {
       spread: None,
       expr: Box::new(Expr::Ident(Ident::new(name.into(), DUMMY_SP))),

--- a/src/transpiling/jsx_string.rs
+++ b/src/transpiling/jsx_string.rs
@@ -1035,6 +1035,18 @@ const a = _jsx(Foo, {
     );
   }
 
+  #[test]
+  fn component_with_jsx_member_test() {
+    test_transform(
+      JsxString::default(),
+      r#"const a = <ctx.Provider value={null} />;"#,
+      r#"import { jsx as _jsx } from "react/jsx-runtime";
+const a = _jsx(ctx.Provider, {
+  "value": null
+});"#,
+    );
+  }
+
   // TODO: What to do with keys?
   // TODO: Should we go with function calls for dynamic attributes instead
   //       of an object for DOM nodes? Would allow us to skip an allocation.

--- a/src/transpiling/jsx_string.rs
+++ b/src/transpiling/jsx_string.rs
@@ -3,6 +3,7 @@ use swc_common::DUMMY_SP;
 use swc_common::Spanned;
 use swc_ecma_ast::*;
 use swc_ecma_utils::prepend_stmt;
+use swc_ecma_utils::quote_ident;
 use swc_ecma_visit::{as_folder, noop_visit_mut_type, VisitMut, VisitMutWith};
 
 struct JsxString {
@@ -213,12 +214,7 @@ impl JsxString {
         match attr {
           JSXAttrOrSpread::JSXAttr(jsx_attr) => {
             let attr_name = get_attr_name(jsx_attr);
-
-            let prop_name = PropName::Str(Str {
-              span: DUMMY_SP,
-              value: attr_name.into(),
-              raw: None,
-            });
+            let prop_name = PropName::Ident(quote_ident!(attr_name));
 
             // Case: <Foo required />
             let Some(attr_value) = &jsx_attr.value else {
@@ -279,11 +275,7 @@ impl JsxString {
       // each child individually might increase compatibility because
       // of `React.Children` API, but it's not good for performance.
       let child_len = el.children.len();
-      let children_name = PropName::Str(Str {
-        span: DUMMY_SP,
-        value: "children".into(),
-        raw: None,
-      });
+      let children_name = PropName::Ident(quote_ident!("children"));
       for child in el.children.iter() {
         match child {
           // Case: <div>foo</div>
@@ -917,10 +909,10 @@ const a = _jsxssr($$_tpl_1, null);"#,
       r#"const a = <div foo="1" {...props} bar="2">foo</div>;"#,
       r#"import { jsx as _jsx } from "react/jsx-runtime";
 const a = _jsx("div", {
-  "foo": "1",
+  foo: "1",
   ...props,
-  "bar": "2",
-  "children": "foo"
+  bar: "2",
+  children: "foo"
 });"#,
     );
   }
@@ -932,10 +924,10 @@ const a = _jsx("div", {
       r#"const a = <div dangerouslySetInnerHTML={{__html: "foo"}}>foo</div>;"#,
       r#"import { jsx as _jsx } from "react/jsx-runtime";
 const a = _jsx("div", {
-  "dangerouslySetInnerHTML": {
+  dangerouslySetInnerHTML: {
     __html: "foo"
   },
-  "children": "foo"
+  children: "foo"
 });"#,
     );
   }
@@ -1023,7 +1015,7 @@ const a = _jsx("div", {
       r#"import { jsx as _jsx } from "react/jsx-runtime";
 const a = _jsx("div", {
   ...props,
-  "children": "hello"
+  children: "hello"
 });"#,
     );
   }
@@ -1035,10 +1027,10 @@ const a = _jsx("div", {
       r#"const a = <div foo="1" {...props} bar="2">hello</div>;"#,
       r#"import { jsx as _jsx } from "react/jsx-runtime";
 const a = _jsx("div", {
-  "foo": "1",
+  foo: "1",
   ...props,
-  "bar": "2",
-  "children": "hello"
+  bar: "2",
+  children: "hello"
 });"#,
     );
   }
@@ -1074,9 +1066,9 @@ const a = _jsx(Foo, null);"#,
       r#"const a = <Foo required foo="1" bar={2} />;"#,
       r#"import { jsx as _jsx } from "react/jsx-runtime";
 const a = _jsx(Foo, {
-  "required": true,
-  "foo": "1",
-  "bar": 2
+  required: true,
+  foo: "1",
+  bar: 2
 });"#,
     );
   }
@@ -1089,7 +1081,7 @@ const a = _jsx(Foo, {
       r#"import { jsx as _jsx } from "react/jsx-runtime";
 const a = _jsx(Foo, {
   ...props,
-  "foo": "1"
+  foo: "1"
 });"#,
     );
   }
@@ -1129,7 +1121,7 @@ const a = _jsx(Foo, {
       r#"const a = <Foo>{2 + 2}</Foo>;"#,
       r#"import { jsx as _jsx } from "react/jsx-runtime";
 const a = _jsx(Foo, {
-  "children": 2 + 2
+  children: 2 + 2
 });"#,
     );
   }
@@ -1144,7 +1136,7 @@ const $$_tpl_1 = [
   "<div>hello</div>"
 ];
 const a = _jsx(Foo, {
-  "bar": _jsxssr($$_tpl_1, null)
+  bar: _jsxssr($$_tpl_1, null)
 });"#,
     );
   }
@@ -1172,7 +1164,7 @@ const a = _jsx(Foo, {
       r#"const a = <ctx.Provider value={null} />;"#,
       r#"import { jsx as _jsx } from "react/jsx-runtime";
 const a = _jsx(ctx.Provider, {
-  "value": null
+  value: null
 });"#,
     );
   }

--- a/src/transpiling/jsx_string.rs
+++ b/src/transpiling/jsx_string.rs
@@ -276,8 +276,9 @@ impl JsxString {
                   }
                 }
               }
-              JSXAttrValue::JSXElement(_) => todo!(),
-              JSXAttrValue::JSXFragment(_) => todo!(),
+              // There is no valid way to construct these
+              JSXAttrValue::JSXElement(_) => {}
+              JSXAttrValue::JSXFragment(_) => {}
             }
           }
           // Case: <Foo {...props} />
@@ -338,7 +339,7 @@ impl JsxString {
             // Invalid, was part of an earlier JSX iteration, but no
             // transform supports it. Babel and TypeScript error when they
             // encounter this.
-            JSXElementChild::JSXSpreadChild(_) => todo!(),
+            JSXElementChild::JSXSpreadChild(_) => {}
           }
         }
         _ => {
@@ -380,7 +381,7 @@ impl JsxString {
               // Invalid, was part of an earlier JSX iteration, but no
               // transform supports it. Babel and TypeScript error when they
               // encounter this.
-              JSXElementChild::JSXSpreadChild(_) => todo!(),
+              JSXElementChild::JSXSpreadChild(_) => {}
             }
           }
 
@@ -538,12 +539,14 @@ impl JsxString {
                     .unwrap()
                     .push_str(serialized_attr.as_str());
                 }
-                Lit::Bool(_) => todo!(),
-                Lit::Null(_) => todo!(),
-                Lit::Num(_) => todo!(),
-                Lit::BigInt(_) => todo!(),
-                Lit::Regex(_) => todo!(),
-                Lit::JSXText(_) => todo!(),
+                // I've never seen this being possible as it would
+                // always be treated as an expression.
+                Lit::Bool(_) => {}
+                Lit::Null(_) => {}
+                Lit::Num(_) => {}
+                Lit::BigInt(_) => {}
+                Lit::Regex(_) => {}
+                Lit::JSXText(_) => {}
               },
               JSXAttrValue::JSXExprContainer(jsx_expr_container) => {
                 strings.last_mut().unwrap().push_str(" ");
@@ -551,7 +554,7 @@ impl JsxString {
                 // eprintln!("jsx_expr_container {:#?}", jsx_expr_container);
                 match &jsx_expr_container.expr {
                   // This is treated as a syntax error in attributes
-                  JSXExpr::JSXEmptyExpr(_) => todo!(),
+                  JSXExpr::JSXEmptyExpr(_) => {}
                   JSXExpr::Expr(expr) => {
                     let mut args: Vec<ExprOrSpread> = vec![];
                     args.push(ExprOrSpread {
@@ -576,10 +579,10 @@ impl JsxString {
                   }
                 }
               }
-              // Cannot occur on DOM elements
-              JSXAttrValue::JSXElement(_) => todo!(),
-              // Cannot occur on DOM elements
-              JSXAttrValue::JSXFragment(_) => todo!(),
+              // These makes no sense on as attribute on HTML elements
+              // so we ignore them.
+              JSXAttrValue::JSXElement(_) => {}
+              JSXAttrValue::JSXFragment(_) => {}
             }
           }
           // Case: <div {...props} />
@@ -643,7 +646,7 @@ impl JsxString {
         // Invalid, was part of an earlier JSX iteration, but no
         // transform supports it. Babel and TypeScript error when they
         // encounter this.
-        JSXElementChild::JSXSpreadChild(_) => todo!(),
+        JSXElementChild::JSXSpreadChild(_) => {}
       }
     }
 
@@ -869,7 +872,7 @@ impl VisitMut for JsxString {
             // Invalid, was part of an earlier JSX iteration, but no
             // transform supports it. Babel and TypeScript error when they
             // encounter this.
-            JSXElementChild::JSXSpreadChild(_) => todo!(),
+            JSXElementChild::JSXSpreadChild(_) => {}
           }
         }
         _ => {

--- a/src/transpiling/jsx_string.rs
+++ b/src/transpiling/jsx_string.rs
@@ -325,10 +325,6 @@ impl JsxString {
     parent_tag_name: Option<String>,
   ) -> Option<Expr> {
     // Add children as a "children" prop.
-    // TODO: Not sure if we should serialize all of them as one big
-    // Fragment or serialize each child individually. Serializing
-    // each child individually might increase compatibility because
-    // of `React.Children` API, but it's not good for performance.
     match children.len() {
       0 => None,
       1 => {

--- a/src/transpiling/jsx_string.rs
+++ b/src/transpiling/jsx_string.rs
@@ -83,16 +83,13 @@ fn serialize_jsx_element_to_string_vec(
     for attr in el.opening.attrs.iter() {
       let mut is_dynamic = false;
       let mut serialized_attr = String::new();
-      let mut name = "".to_string();
       // Case: <button class="btn">
       match attr {
         JSXAttrOrSpread::JSXAttr(jsx_attr) => {
-          match &jsx_attr.name {
+          let attr_name = match &jsx_attr.name {
             // Case: <button class="btn">
             JSXAttrName::Ident(ident) => {
-              name = ident.sym.to_string();
-              let serialized = normalize_dom_attr_name(&name);
-              serialized_attr.push_str(serialized.as_str());
+              normalize_dom_attr_name(&ident.sym.to_string())
             }
             // Case (svg only): <a xlink:href="#">...</a>
             JSXAttrName::JSXNamespacedName(_namespace_name) => {
@@ -100,6 +97,8 @@ fn serialize_jsx_element_to_string_vec(
               todo!()
             }
           };
+
+          serialized_attr.push_str(attr_name.as_str());
 
           // Case: <input required />
           let Some(attr_value) = &jsx_attr.value else {
@@ -140,7 +139,7 @@ fn serialize_jsx_element_to_string_vec(
                       KeyValueProp {
                         key: PropName::Str(Str {
                           span: DUMMY_SP,
-                          value: name.into(),
+                          value: attr_name.into(),
                           raw: None,
                         }),
                         value: expr.clone(),
@@ -286,7 +285,7 @@ impl JsxString {
   fn inject_runtime(&mut self) {
     let imports: Vec<(Ident, Ident)> = vec![];
     if self.development {
-      if let Some(jsx_ident) = &self.import_jsx {
+      if let Some(_jsx_ident) = &self.import_jsx {
         // imports.
       }
     }

--- a/src/transpiling/jsx_string.rs
+++ b/src/transpiling/jsx_string.rs
@@ -1720,10 +1720,11 @@ const a = _jsx(a.b.c.d, {
 
   #[test]
   fn skip_component_child_serialization_test() {
-    let mut defaults = JsxString::default();
-    defaults.skip_child_serialization = Some(vec!["Head".to_string()]);
     test_transform(
-      defaults,
+      JsxString {
+        skip_child_serialization: Some(vec!["Head".to_string()]),
+        ..Default::default()
+      },
       r#"const a = <Head><title>foo</title></Head>;"#,
       r#"import { jsx as _jsx } from "react/jsx-runtime";
 const a = _jsx(Head, {

--- a/src/transpiling/jsx_string.rs
+++ b/src/transpiling/jsx_string.rs
@@ -512,13 +512,15 @@ impl JsxString {
             match attr_value {
               JSXAttrValue::Lit(lit) => match lit {
                 Lit::Str(string_lit) => {
-                  // Edge Case: The "key" attribute is a special one in
-                  // most frameworks. Some frameworks may want to
-                  // serialize it, other's don't. To support both use
-                  // cases we'll always pass it to `jsxattr()` so that
-                  // they can decide for themselves what to do with it.
+                  // Edge Case: Both "key" and "ref" attributes are
+                  // special attributes in most frameworks. Some
+                  // frameworks may want to serialize it, other's don't.
+                  // To support both use cases we'll always pass them to
+                  // `jsxattr()` so that frameowrks can decide for
+                  // themselves what to do with it.
                   // Case: <div key="123" />
-                  if attr_name == "key" {
+                  // Case: <div ref="123" />
+                  if attr_name == "key" || attr_name == "ref" {
                     strings.last_mut().unwrap().push_str(" ");
                     strings.push("".to_string());
                     let expr = self.convert_to_jsx_attr_call(
@@ -1069,6 +1071,20 @@ const $$_tpl_1 = [
   ">foo</div>"
 ];
 const a = _jsxssr($$_tpl_1, _jsxattr("key", "foo"));"#,
+    );
+  }
+
+  #[test]
+  fn ref_attr_test() {
+    test_transform(
+      JsxString::default(),
+      r#"const a = <div ref="foo">foo</div>;"#,
+      r#"import { jsxssr as _jsxssr, jsxattr as _jsxattr } from "react/jsx-runtime";
+const $$_tpl_1 = [
+  "<div ",
+  ">foo</div>"
+];
+const a = _jsxssr($$_tpl_1, _jsxattr("ref", "foo"));"#,
     );
   }
 

--- a/src/transpiling/jsx_string.rs
+++ b/src/transpiling/jsx_string.rs
@@ -485,22 +485,21 @@ impl JsxString {
     }
 
     strings.last_mut().unwrap().push_str("<");
+    // TODO: Escape
     strings.last_mut().unwrap().push_str(name.as_str());
 
     if !el.opening.attrs.is_empty() {
       for attr in el.opening.attrs.iter() {
-        let mut serialized_attr = String::new();
         // Case: <button class="btn">
         match attr {
           JSXAttrOrSpread::JSXAttr(jsx_attr) => {
             let attr_name = get_attr_name(jsx_attr);
 
-            serialized_attr.push_str(attr_name.as_str());
-
             // Case: <input required />
             let Some(attr_value) = &jsx_attr.value else {
               strings.last_mut().unwrap().push_str(" ");
-              strings.last_mut().unwrap().push_str(&serialized_attr);
+              // TODO: Escape
+              strings.last_mut().unwrap().push_str(attr_name.as_str());
               continue;
             };
 
@@ -531,11 +530,15 @@ impl JsxString {
                     continue;
                   }
 
-                  serialized_attr.push_str("=\"");
-                  serialized_attr
-                    .push_str(string_lit.value.to_string().as_str());
-                  serialized_attr.push_str("\"");
-                  strings.last_mut().unwrap().push_str(" ");
+                  let serialized_attr = format!(
+                    " {}=\"{}\"",
+                    // TODO: Escape
+                    attr_name.as_str(),
+                    // TODO: Escape
+                    string_lit.value.to_string().as_str()
+                  );
+
+                  strings.last_mut().unwrap().push_str("");
                   strings
                     .last_mut()
                     .unwrap()
@@ -618,6 +621,7 @@ impl JsxString {
           strings
             .last_mut()
             .unwrap()
+            // TODO: Escape
             .push_str(jsx_text.value.to_string().as_str());
         }
         // Case: <div>{2 + 2}</div>

--- a/src/transpiling/jsx_string.rs
+++ b/src/transpiling/jsx_string.rs
@@ -456,7 +456,7 @@ impl JsxString {
       ExprOrSpread {
         spread: None,
         expr: Box::new(expr.clone()),
-      }
+      },
     ];
 
     CallExpr {

--- a/src/transpiling/jsx_string.rs
+++ b/src/transpiling/jsx_string.rs
@@ -471,21 +471,20 @@ impl JsxString {
       }
     }
 
+    strings.last_mut().unwrap().push_str(">");
+
     // There are no self closing elements in HTML, only void elements.
     // Void elements are a fixed list of elements that cannot have
     // child nodes.
     // See https://developer.mozilla.org/en-US/docs/Glossary/Void_element
-    // Case: <br />
-    // Case: <meta />
+    // Case: <br /> -> <br>
+    // Case: <meta /> -> <meta>
     if is_void_element(&name) {
       // Since self closing tags don't exist in HTML we don't need to
       // add the "/" character. If the "/" character is present,
       // browsers will ignore it anyway.
-      strings.last_mut().unwrap().push_str(">");
       return;
     }
-
-    strings.last_mut().unwrap().push_str(">");
 
     for child in el.children.iter() {
       match child {

--- a/src/transpiling/jsx_string.rs
+++ b/src/transpiling/jsx_string.rs
@@ -478,7 +478,10 @@ impl JsxString {
     // Case: <br />
     // Case: <meta />
     if is_void_element(&name) {
-      strings.last_mut().unwrap().push_str(" />");
+      // Since self closing tags don't exist in HTML we don't need to
+      // add the "/" character. If the "/" character is present,
+      // browsers will ignore it anyway.
+      strings.last_mut().unwrap().push_str(">");
       return;
     }
 
@@ -822,7 +825,7 @@ const a = _jsxssr($$_tpl_1, null);"#,
       r#"const a = <br></br>;"#,
       r#"import { jsxssr as _jsxssr } from "react/jsx-runtime";
 const $$_tpl_1 = [
-  "<br />"
+  "<br>"
 ];
 const a = _jsxssr($$_tpl_1, null);"#,
     );
@@ -857,7 +860,7 @@ const a = _jsxssr($$_tpl_1, null);"#,
       r#"const a = <input type="checkbox" checked />;"#,
       r#"import { jsxssr as _jsxssr } from "react/jsx-runtime";
 const $$_tpl_1 = [
-  '<input type="checkbox" checked />'
+  '<input type="checkbox" checked>'
 ];
 const a = _jsxssr($$_tpl_1, null);"#,
     );

--- a/src/transpiling/jsx_string.rs
+++ b/src/transpiling/jsx_string.rs
@@ -448,16 +448,16 @@ impl JsxString {
   }
 
   fn convert_to_jsx_attr_call(&mut self, name: &str, expr: &Expr) -> CallExpr {
-    let mut args: Vec<ExprOrSpread> = vec![];
-    args.push(ExprOrSpread {
-      spread: None,
-      expr: Box::new(string_lit_expr(name.to_string())),
-    });
-
-    args.push(ExprOrSpread {
-      spread: None,
-      expr: Box::new(expr.clone()),
-    });
+    let args = vec![
+      ExprOrSpread {
+        spread: None,
+        expr: Box::new(string_lit_expr(name.to_string())),
+      },
+      ExprOrSpread {
+        spread: None,
+        expr: Box::new(expr.clone()),
+      }
+    ];
 
     CallExpr {
       span: DUMMY_SP,
@@ -479,7 +479,7 @@ impl JsxString {
       match child {
         // Case: <div>foo</div>
         JSXElementChild::JSXText(jsx_text) => {
-          let escaped_text = escape_html(&jsx_text.value.to_string());
+          let escaped_text = escape_html(jsx_text.value.as_ref());
           strings.last_mut().unwrap().push_str(escaped_text.as_str());
         }
         // Case: <div>{2 + 2}</div>
@@ -550,7 +550,7 @@ impl JsxString {
       strings.push("".to_string());
     }
 
-    strings.last_mut().unwrap().push_str("<");
+    strings.last_mut().unwrap().push('<');
 
     let escaped_name = escape_html(&name);
     strings.last_mut().unwrap().push_str(escaped_name.as_str());
@@ -564,7 +564,7 @@ impl JsxString {
 
             // Case: <input required />
             let Some(attr_value) = &jsx_attr.value else {
-              strings.last_mut().unwrap().push_str(" ");
+              strings.last_mut().unwrap().push(' ');
               let escaped_attr_name = escape_html(&attr_name);
               strings
                 .last_mut()
@@ -590,7 +590,7 @@ impl JsxString {
                   // Case: <div key="123" />
                   // Case: <div ref="123" />
                   if attr_name == "key" || attr_name == "ref" {
-                    strings.last_mut().unwrap().push_str(" ");
+                    strings.last_mut().unwrap().push(' ');
                     strings.push("".to_string());
                     let expr = self.convert_to_jsx_attr_call(
                       &attr_name,
@@ -603,7 +603,7 @@ impl JsxString {
                   let serialized_attr = format!(
                     " {}=\"{}\"",
                     escape_html(&attr_name).as_str(),
-                    escape_html(&string_lit.value.to_string()).as_str()
+                    escape_html(string_lit.value.as_ref()).as_str()
                   );
 
                   strings.last_mut().unwrap().push_str("");
@@ -622,7 +622,7 @@ impl JsxString {
                 Lit::JSXText(_) => {}
               },
               JSXAttrValue::JSXExprContainer(jsx_expr_container) => {
-                strings.last_mut().unwrap().push_str(" ");
+                strings.last_mut().unwrap().push(' ');
                 strings.push("".to_string());
                 // eprintln!("jsx_expr_container {:#?}", jsx_expr_container);
                 match &jsx_expr_container.expr {
@@ -648,7 +648,7 @@ impl JsxString {
       }
     }
 
-    strings.last_mut().unwrap().push_str(">");
+    strings.last_mut().unwrap().push('>');
 
     // There are no self closing elements in HTML, only void elements.
     // Void elements are a fixed list of elements that cannot have

--- a/src/transpiling/jsx_string.rs
+++ b/src/transpiling/jsx_string.rs
@@ -69,6 +69,7 @@ fn serialize_jsx_element_to_string_vec(
   el: JSXElement,
 ) -> (Vec<String>, Vec<Box<Expr>>) {
   let name = match el.opening.name {
+    // Case: <div />
     JSXElementName::Ident(ident) => ident.sym.to_string(),
     _ => todo!(),
   };
@@ -188,7 +189,7 @@ fn serialize_jsx_element_to_string_vec(
   // See https://developer.mozilla.org/en-US/docs/Glossary/Void_element
   // Case: <br />
   // Case: <meta />
-  if is_void_element(name) {
+  if is_void_element(&name) {
     strings.last_mut().unwrap().push_str(" />");
     return (strings, dynamic_exprs);
   }
@@ -210,7 +211,7 @@ fn serialize_jsx_element_to_string_vec(
           // Empty JSX expressions can be ignored as they have no content
           // Case: <div>{}</div>
           // Case: <div>{/* fooo */}</div>
-          JSXExpr::JSXEmptyExpr(_jsx_empty_expr) => continue,
+          JSXExpr::JSXEmptyExpr(_) => continue,
           JSXExpr::Expr(expr) => match &**expr {
             Expr::Ident(ident) => {
               strings.push("".to_string());

--- a/src/transpiling/jsx_string.rs
+++ b/src/transpiling/jsx_string.rs
@@ -1,57 +1,111 @@
-use swc_atoms::{js_word, Atom, JsWord};
+use swc_common::DUMMY_SP;
+// use swc_atoms::{js_word, Atom, JsWord};
 use swc_common::{
-  comments::{Comment, CommentKind, Comments},
-  errors::HANDLER,
-  iter::IdentifyLast,
-  sync::Lrc,
+  //   comments::{Comment, CommentKind, Comments},
+  //   errors::HANDLER,
+  //   iter::IdentifyLast,
+  //   sync::Lrc,
   util::take::Take,
-  FileName, Mark, SourceMap, Span, Spanned, DUMMY_SP,
+  //   FileName, Mark, SourceMap,
+  Span,
+  Spanned,
 };
 use swc_ecma_ast::*;
-use swc_ecma_utils::{
-  drop_span, member_expr, prepend_stmt, private_ident, quote_ident, undefined,
-  ExprFactory,
-};
+// use swc_ecma_utils::{
+//   drop_span, member_expr, prepend_stmt, private_ident, quote_ident, undefined,
+//   ExprFactory,
+// };
 use swc_ecma_visit::{
   as_folder, noop_visit_mut_type, Fold, VisitMut, VisitMutWith,
 };
 
-struct JsxString {}
+struct JsxString {
+  next_index: usize,
+}
+
+impl Default for JsxString {
+  fn default() -> Self {
+    Self { next_index: 0 }
+  }
+}
+
+fn create_tpl_binding_name(index: usize) -> String {
+  format!("$$_tpl_{index}")
+}
+
+impl JsxString {
+  fn generate_tpl_join(&self, el: JSXElement) -> Expr {
+    let name = create_tpl_binding_name(self.next_index);
+    let span = el.span();
+
+    // $$_tpl_1.join("");
+    Expr::Call(CallExpr {
+      span,
+      callee: Callee::Expr(Box::new(Expr::Member(MemberExpr {
+        span: DUMMY_SP,
+        obj: Box::new(Expr::Ident(Ident::new(name.into(), DUMMY_SP))),
+        prop: MemberProp::Ident(Ident::new("join".into(), DUMMY_SP)),
+      }))),
+      args: vec![ExprOrSpread {
+        spread: None,
+        expr: Box::new(Expr::Lit(Lit::Str(Str {
+          span: DUMMY_SP,
+          value: "".into(),
+          raw: None,
+        }))),
+      }],
+      type_args: Default::default(),
+    })
+  }
+}
 
 impl VisitMut for JsxString {
   noop_visit_mut_type!();
+
+  fn visit_mut_module(&mut self, module: &mut Module) {
+    eprintln!("ast {:#?}", module);
+    module.visit_mut_children_with(self);
+  }
 
   fn visit_mut_expr(&mut self, expr: &mut Expr) {
     // let top_level_node = self.top_level_node;
     // let mut did_work = false;
 
-    // if let Expr::JSXElement(el) = expr {
-    //   did_work = true;
-    //   // <div></div> => React.createElement('div', null);
-    //   *expr = self.jsx_elem_to_expr(*el.take());
-    // } else if let Expr::JSXFragment(frag) = expr {
-    //   // <></> => React.createElement(React.Fragment, null);
-    //   did_work = true;
-    //   *expr = self.jsx_frag_to_expr(frag.take());
-    // } else if let Expr::Paren(ParenExpr {
-    //   expr: inner_expr, ..
-    // }) = expr
-    // {
-    //   if let Expr::JSXElement(el) = &mut **inner_expr {
-    //     did_work = true;
-    //     *expr = self.jsx_elem_to_expr(*el.take());
-    //   } else if let Expr::JSXFragment(frag) = &mut **inner_expr {
-    //     // <></> => React.createElement(React.Fragment, null);
-    //     did_work = true;
-    //     *expr = self.jsx_frag_to_expr(frag.take());
-    //   }
-    // }
+    if let Expr::JSXElement(el) = expr {
+      // TODO:
+      // 1. create a `_tpl_<name>` which is an array literal
+      // 2. transform the element into a list of string literals and
+      //    push them to the `_tpl_<name>` literal node
+      // 3. change the `expr` to be `_tpl_<name>.join("");`
+
+      self.next_index += 1;
+
+      //   did_work = true;
+      //   // <div></div> => React.createElement('div', null);
+      *expr = self.generate_tpl_join(*el.take());
+    } else if let Expr::JSXFragment(frag) = expr {
+      //   // <></> => React.createElement(React.Fragment, null);
+      //   did_work = true;
+      //   *expr = self.jsx_frag_to_expr(frag.take());
+    } else if let Expr::Paren(ParenExpr {
+      expr: inner_expr, ..
+    }) = expr
+    {
+      if let Expr::JSXElement(el) = &mut **inner_expr {
+        // did_work = true;
+        // *expr = self.jsx_elem_to_expr(*el.take());
+      } else if let Expr::JSXFragment(frag) = &mut **inner_expr {
+        // <></> => React.createElement(React.Fragment, null);
+        // did_work = true;
+        // *expr = self.jsx_frag_to_expr(frag.take());
+      }
+    }
 
     // if did_work {
     //   self.top_level_node = false;
     // }
 
-    // expr.visit_mut_children_with(self);
+    expr.visit_mut_children_with(self);
 
     // self.top_level_node = top_level_node;
   }
@@ -80,10 +134,13 @@ mod tests {
   #[test]
   fn basic_test() {
     test_transform(
-      JsxString {},
-      r#"const a = <div>Hello!</div>;"#,
-      r#"const _tpl = ["<div>Hello!</div>"];
-const a = _tpl.join("");"#,
+      JsxString::default(),
+      r#"const a = <div>Hello!</div>;
+const b = <div>Hello!</div>;"#,
+      r#"const $$_tpl_1 = ["<div>Hello!</div>"];
+const $$_tpl_2 = ["<div>Hello!</div>"];
+const a = $$_tpl_1.join("");
+const b = $$_tpl_2.join("");"#,
     );
   }
 
@@ -107,7 +164,7 @@ const a = _tpl.join("");"#,
     );
     let input = StringInput::from(&*source_file);
     let syntax = Syntax::Typescript(TsConfig {
-        tsx: true,
+      tsx: true,
       ..Default::default()
     });
     let mut parser = Parser::new(syntax, input, None);

--- a/src/transpiling/jsx_string.rs
+++ b/src/transpiling/jsx_string.rs
@@ -446,19 +446,6 @@ const a = renderFunction($$_tpl_1, null);"#,
     );
   }
 
-  #[ignore]
-  #[test]
-  fn nested_elements_test() {
-    test_transform(
-      JsxString::default(),
-      r#"const a = <div>foo<p>bar</p></div>;"#,
-      r#"const $$_tpl_1 = [
-  <div>foo<p>bar</p></div>
-];
-const a = renderFunction($$_tpl_1, null);"#,
-    );
-  }
-
   // TODO: What to do with keys?
   // TODO: What to do with components?
   //       1. Convert to function calls, this would make it insanely fast,

--- a/src/transpiling/jsx_string.rs
+++ b/src/transpiling/jsx_string.rs
@@ -1,0 +1,133 @@
+use swc_atoms::{js_word, Atom, JsWord};
+use swc_common::{
+  comments::{Comment, CommentKind, Comments},
+  errors::HANDLER,
+  iter::IdentifyLast,
+  sync::Lrc,
+  util::take::Take,
+  FileName, Mark, SourceMap, Span, Spanned, DUMMY_SP,
+};
+use swc_ecma_ast::*;
+use swc_ecma_utils::{
+  drop_span, member_expr, prepend_stmt, private_ident, quote_ident, undefined,
+  ExprFactory,
+};
+use swc_ecma_visit::{
+  as_folder, noop_visit_mut_type, Fold, VisitMut, VisitMutWith,
+};
+
+struct JsxString {}
+
+impl VisitMut for JsxString {
+  noop_visit_mut_type!();
+
+  fn visit_mut_expr(&mut self, expr: &mut Expr) {
+    // let top_level_node = self.top_level_node;
+    // let mut did_work = false;
+
+    // if let Expr::JSXElement(el) = expr {
+    //   did_work = true;
+    //   // <div></div> => React.createElement('div', null);
+    //   *expr = self.jsx_elem_to_expr(*el.take());
+    // } else if let Expr::JSXFragment(frag) = expr {
+    //   // <></> => React.createElement(React.Fragment, null);
+    //   did_work = true;
+    //   *expr = self.jsx_frag_to_expr(frag.take());
+    // } else if let Expr::Paren(ParenExpr {
+    //   expr: inner_expr, ..
+    // }) = expr
+    // {
+    //   if let Expr::JSXElement(el) = &mut **inner_expr {
+    //     did_work = true;
+    //     *expr = self.jsx_elem_to_expr(*el.take());
+    //   } else if let Expr::JSXFragment(frag) = &mut **inner_expr {
+    //     // <></> => React.createElement(React.Fragment, null);
+    //     did_work = true;
+    //     *expr = self.jsx_frag_to_expr(frag.take());
+    //   }
+    // }
+
+    // if did_work {
+    //   self.top_level_node = false;
+    // }
+
+    // expr.visit_mut_children_with(self);
+
+    // self.top_level_node = top_level_node;
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use crate::swc::ast::Module;
+  use crate::swc::codegen::text_writer::JsWriter;
+  use crate::swc::codegen::Node;
+  use crate::swc::common::FileName;
+  use crate::swc::common::SourceMap;
+  use crate::swc::parser::Parser;
+  use crate::swc::parser::StringInput;
+  use crate::swc::parser::Syntax;
+  use crate::swc::parser::TsConfig;
+  use crate::swc::visit::Fold;
+  use crate::swc::visit::FoldWith;
+  use crate::ModuleSpecifier;
+  use crate::ES_VERSION;
+  use pretty_assertions::assert_eq;
+  use std::rc::Rc;
+
+  use super::*;
+
+  #[test]
+  fn basic_test() {
+    test_transform(
+      JsxString {},
+      r#"const a = <div>Hello!</div>;"#,
+      r#"const _tpl = ["<div>Hello!</div>"];
+const a = _tpl.join("");"#,
+    );
+  }
+
+  #[track_caller]
+  fn test_transform(
+    transform: impl VisitMut,
+    src: &str,
+    expected_output: &str,
+  ) {
+    let (source_map, module) = parse(src);
+    let mut transform_folder = as_folder(transform);
+    let output = print(source_map, module.fold_with(&mut transform_folder));
+    assert_eq!(output, format!("{}\n", expected_output));
+  }
+
+  fn parse(src: &str) -> (Rc<SourceMap>, Module) {
+    let source_map = Rc::new(SourceMap::default());
+    let source_file = source_map.new_source_file(
+      FileName::Url(ModuleSpecifier::parse("file:///test.ts").unwrap()),
+      src.to_string(),
+    );
+    let input = StringInput::from(&*source_file);
+    let syntax = Syntax::Typescript(TsConfig {
+        tsx: true,
+      ..Default::default()
+    });
+    let mut parser = Parser::new(syntax, input, None);
+    (source_map, parser.parse_module().unwrap())
+  }
+
+  fn print(source_map: Rc<SourceMap>, module: Module) -> String {
+    let mut buf = vec![];
+    {
+      let mut writer =
+        Box::new(JsWriter::new(source_map.clone(), "\n", &mut buf, None));
+      writer.set_indent_str("  "); // two spaces
+      let mut emitter = crate::swc::codegen::Emitter {
+        cfg: crate::swc_codegen_config(),
+        comments: None,
+        cm: source_map,
+        wr: writer,
+      };
+      module.emit_with(&mut emitter).unwrap();
+    }
+    String::from_utf8(buf).unwrap()
+  }
+}

--- a/src/transpiling/jsx_string.rs
+++ b/src/transpiling/jsx_string.rs
@@ -134,7 +134,7 @@ impl JsxString {
     }
   }
 
-  /// Mark `jsxssr`` as being used and return the identifier.
+  /// Mark `jsxssr` as being used and return the identifier.
   fn get_jsx_ssr_identifier(&mut self) -> Ident {
     match &self.import_jsx_ssr {
       Some(ident) => ident.clone(),

--- a/src/transpiling/jsx_string.rs
+++ b/src/transpiling/jsx_string.rs
@@ -843,9 +843,7 @@ impl JsxString {
       spread: None,
       expr: Box::new(Expr::Ident(Ident::new(name.into(), DUMMY_SP))),
     });
-    if dynamic_exprs.is_empty() {
-      args.push(null_arg());
-    } else {
+    if !dynamic_exprs.is_empty() {
       for dynamic_expr in dynamic_exprs.into_iter() {
         args.push(ExprOrSpread {
           spread: None,
@@ -854,7 +852,7 @@ impl JsxString {
       }
     }
 
-    // Case: _jsxssr($$_tpl_1, null);
+    // Case: _jsxssr($$_tpl_1);
     let jsx_ident = self.get_jsx_ssr_identifier();
 
     Expr::Call(CallExpr {
@@ -1101,7 +1099,7 @@ const $$_tpl_3 = [
   ">Hello ",
   "!</button>"
 ];
-const a = _jsxssr($$_tpl_1, null);
+const a = _jsxssr($$_tpl_1);
 const b = _jsxssr($$_tpl_2, name);
 const c = _jsxssr($$_tpl_3, _jsxattr("onclick", onClick), name);"#,
     );
@@ -1116,7 +1114,7 @@ const c = _jsxssr($$_tpl_3, _jsxattr("onclick", onClick), name);"#,
 const $$_tpl_1 = [
   "<div></div>"
 ];
-const a = _jsxssr($$_tpl_1, null);"#,
+const a = _jsxssr($$_tpl_1);"#,
     );
 
     // Void elements
@@ -1127,7 +1125,7 @@ const a = _jsxssr($$_tpl_1, null);"#,
 const $$_tpl_1 = [
   "<br>"
 ];
-const a = _jsxssr($$_tpl_1, null);"#,
+const a = _jsxssr($$_tpl_1);"#,
     );
   }
 
@@ -1147,7 +1145,7 @@ const a = _jsxssr($$_tpl_1, null);"#,
         format!("const a = <label {}=\"foo\">label</label>", &mapping.0)
           .as_str(),
         format!(
-          "{}\nconst $$_tpl_1 = [\n  '<label {}=\"foo\">label</label>'\n];\nconst a = _jsxssr($$_tpl_1, null);",
+          "{}\nconst $$_tpl_1 = [\n  '<label {}=\"foo\">label</label>'\n];\nconst a = _jsxssr($$_tpl_1);",
           "import { jsxssr as _jsxssr } from \"react/jsx-runtime\";",
           &mapping.1
         )
@@ -1178,7 +1176,7 @@ const a = _jsxssr($$_tpl_1, null);"#,
 const $$_tpl_1 = [
   '<input type="checkbox" checked>'
 ];
-const a = _jsxssr($$_tpl_1, null);"#,
+const a = _jsxssr($$_tpl_1);"#,
     );
 
     test_transform(
@@ -1216,7 +1214,7 @@ const a = _jsxssr($$_tpl_1, _jsxattr("bar", 2));"#,
 const $$_tpl_1 = [
   '<a href="foo">foo</a>'
 ];
-const a = _jsxssr($$_tpl_1, null);"#,
+const a = _jsxssr($$_tpl_1);"#,
     );
 
     test_transform(
@@ -1226,7 +1224,7 @@ const a = _jsxssr($$_tpl_1, null);"#,
 const $$_tpl_1 = [
   '<a foo:bar="foo">foo</a>'
 ];
-const a = _jsxssr($$_tpl_1, null);"#,
+const a = _jsxssr($$_tpl_1);"#,
     );
   }
 
@@ -1323,7 +1321,7 @@ const a = _jsxssr($$_tpl_1, _jsxattr("ref", "foo"));"#,
 const $$_tpl_1 = [
   '<div class="a&amp;&lt;&gt;&#39;">foo</div>'
 ];
-const a = _jsxssr($$_tpl_1, null);"#,
+const a = _jsxssr($$_tpl_1);"#,
     );
   }
 
@@ -1336,7 +1334,7 @@ const a = _jsxssr($$_tpl_1, null);"#,
 const $$_tpl_1 = [
   "<div>&quot;a&amp;&gt;&#39;</div>"
 ];
-const a = _jsxssr($$_tpl_1, null);"#,
+const a = _jsxssr($$_tpl_1);"#,
     );
   }
 
@@ -1362,7 +1360,7 @@ const a = _jsx("a:b", {
 const $$_tpl_1 = [
   "<p></p>"
 ];
-const a = _jsxssr($$_tpl_1, null);"#,
+const a = _jsxssr($$_tpl_1);"#,
     );
   }
 
@@ -1432,9 +1430,9 @@ const $$_tpl_2 = [
 ];
 const a = _jsx(Foo, {
   children: [
-    _jsxssr($$_tpl_1, null),
+    _jsxssr($$_tpl_1),
     "foo",
-    _jsxssr($$_tpl_2, null)
+    _jsxssr($$_tpl_2)
   ]
 });"#,
     );
@@ -1449,7 +1447,7 @@ const a = _jsx(Foo, {
 const $$_tpl_1 = [
   "<div>foo<p>bar</p></div>"
 ];
-const a = _jsxssr($$_tpl_1, null);"#,
+const a = _jsxssr($$_tpl_1);"#,
     );
   }
 
@@ -1566,7 +1564,7 @@ const $$_tpl_1 = [
   "<span>hello</span>"
 ];
 const a = _jsx(Foo, {
-  children: _jsxssr($$_tpl_1, null)
+  children: _jsxssr($$_tpl_1)
 });"#,
     );
   }
@@ -1582,7 +1580,7 @@ const $$_tpl_1 = [
 ];
 const a = _jsx(Foo, {
   children: [
-    _jsxssr($$_tpl_1, null),
+    _jsxssr($$_tpl_1),
     "foo",
     _jsx(Bar, null),
     "asdf"
@@ -1605,10 +1603,10 @@ const $$_tpl_2 = [
 ];
 const a = _jsx(Foo, {
   children: [
-    _jsxssr($$_tpl_1, null),
+    _jsxssr($$_tpl_1),
     "foo",
     _jsx(Bar, {
-      children: _jsxssr($$_tpl_2, null)
+      children: _jsxssr($$_tpl_2)
     })
   ]
 });"#,
@@ -1637,7 +1635,7 @@ const $$_tpl_1 = [
   "<div>hello</div>"
 ];
 const a = _jsx(Foo, {
-  bar: _jsxssr($$_tpl_1, null)
+  bar: _jsxssr($$_tpl_1)
 });"#,
     );
 

--- a/src/transpiling/jsx_string.rs
+++ b/src/transpiling/jsx_string.rs
@@ -1139,7 +1139,6 @@ const a = _jsx(ctx.Provider, {
   // TODO: What to do with "dangerouslySetInnerHTML"?
   // TODO: Fresh specific: <Head> opt out? Or maybe move Fresh users to a
   //       different pattern
-  // TODO: Fresh specific: what about island detection?
 
   //   #[test]
   //   fn basic_test_with_imports() {

--- a/src/transpiling/jsx_string.rs
+++ b/src/transpiling/jsx_string.rs
@@ -872,6 +872,17 @@ const $$_tpl_1 = [
 ];
 const a = _jsxssr($$_tpl_1, null);"#,
     );
+
+    test_transform(
+      JsxString::default(),
+      r#"const a = <input type="checkbox" checked={false} />;"#,
+      r#"import { jsxssr as _jsxssr, jsxattr as _jsxattr } from "react/jsx-runtime";
+const $$_tpl_1 = [
+  '<input type="checkbox" ',
+  ">"
+];
+const a = _jsxssr($$_tpl_1, _jsxattr("checked", false));"#,
+    );
   }
 
   #[test]

--- a/src/transpiling/jsx_string.rs
+++ b/src/transpiling/jsx_string.rs
@@ -264,7 +264,7 @@ fn is_serializable(opening: &JSXOpeningElement) -> bool {
 fn string_lit_expr(str: String) -> Expr {
   Expr::Lit(Lit::Str(Str {
     span: DUMMY_SP,
-    value: str.to_string().as_str().into(),
+    value: str.as_str().into(),
     raw: None,
   }))
 }

--- a/src/transpiling/jsx_string.rs
+++ b/src/transpiling/jsx_string.rs
@@ -1735,9 +1735,6 @@ const a = _jsx(Head, {
     );
   }
 
-  // TODO: Fresh specific: <Head> opt out? Or maybe move Fresh users to a
-  //       different pattern
-
   //   #[test]
   //   fn basic_test_with_imports() {
   //     test_transform(

--- a/src/transpiling/jsx_string.rs
+++ b/src/transpiling/jsx_string.rs
@@ -1,6 +1,6 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
 use swc_common::DUMMY_SP;
-// use swc_atoms::{js_word, Atom, JsWord};
-// use swc_common::Spanned;
 use swc_ecma_ast::*;
 use swc_ecma_utils::prepend_stmt;
 use swc_ecma_utils::quote_ident;

--- a/src/transpiling/jsx_string.rs
+++ b/src/transpiling/jsx_string.rs
@@ -184,7 +184,7 @@ impl JsxString {
       expr: Box::new(name_expr),
     });
 
-    // Serialize component attributes
+    // Serialize attributes
     // Case: <Foo />
     // Case: <Foo foo="1" bar={2} />
     // Case: <Foo baz={<div />} />

--- a/src/transpiling/jsx_string.rs
+++ b/src/transpiling/jsx_string.rs
@@ -269,8 +269,6 @@ fn string_lit_expr(str: String) -> Expr {
   }))
 }
 
-// TODO: Should this use an external crate? Not sure how much of an
-// impact this has on perf
 fn escape_html(str: &str) -> String {
   str
     .replace('&', "&amp;")
@@ -783,7 +781,6 @@ impl JsxString {
               JSXAttrValue::JSXExprContainer(jsx_expr_container) => {
                 strings.last_mut().unwrap().push(' ');
                 strings.push("".to_string());
-                // eprintln!("jsx_expr_container {:#?}", jsx_expr_container);
                 match &jsx_expr_container.expr {
                   // This is treated as a syntax error in attributes
                   JSXExpr::JSXEmptyExpr(_) => {}
@@ -948,7 +945,6 @@ impl VisitMut for JsxString {
   noop_visit_mut_type!();
 
   fn visit_mut_module(&mut self, module: &mut Module) {
-    // eprintln!("ast {:#?}", module);
     module.visit_mut_children_with(self);
     for (idx, strings) in self.templates.iter().rev() {
       let elems: Vec<Option<ExprOrSpread>> = strings

--- a/src/transpiling/jsx_string.rs
+++ b/src/transpiling/jsx_string.rs
@@ -363,7 +363,7 @@ impl JsxString {
     //
     // Case: <div {...props} />
     // Case: <div class="foo" {...{ class: "bar"}} />
-    // Case: <div {...{ class: "foo"} class="bar"}>foo</div>
+    // Case: <div {...{ class: "foo"}} class="bar"}>foo</div>
     if contains_jsx_spread_attr(&el.opening) {
       let expr = Expr::Call(self.serialize_jsx_to_call_expr(&el));
       strings.push("".to_string());

--- a/src/transpiling/jsx_string.rs
+++ b/src/transpiling/jsx_string.rs
@@ -58,11 +58,23 @@ fn normalize_dom_attr_name(name: &str) -> String {
 
 // See: https://developer.mozilla.org/en-US/docs/Glossary/Void_element
 fn is_void_element(name: &str) -> bool {
-  match name {
-    "area" | "base" | "br" | "col" | "embed" | "hr" | "img" | "input"
-    | "link" | "meta" | "param" | "source" | "track" | "wbr" => true,
-    _ => false,
-  }
+  matches!(
+    name,
+    "area"
+      | "base"
+      | "br"
+      | "col"
+      | "embed"
+      | "hr"
+      | "img"
+      | "input"
+      | "link"
+      | "meta"
+      | "param"
+      | "source"
+      | "track"
+      | "wbr"
+  )
 }
 
 fn null_arg() -> ExprOrSpread {
@@ -75,7 +87,7 @@ fn null_arg() -> ExprOrSpread {
 fn get_attr_name(jsx_attr: &JSXAttr) -> String {
   match &jsx_attr.name {
     // Case: <button class="btn">
-    JSXAttrName::Ident(ident) => normalize_dom_attr_name(&ident.sym.as_ref()),
+    JSXAttrName::Ident(ident) => normalize_dom_attr_name(ident.sym.as_ref()),
     // Case (svg only): <a xlink:href="#">...</a>
     JSXAttrName::JSXNamespacedName(_namespace_name) => {
       // TODO: Only support "xlink:href", but convert it to "href"

--- a/src/transpiling/mod.rs
+++ b/src/transpiling/mod.rs
@@ -314,7 +314,6 @@ pub fn fold_program(
       as_folder(jsx_precompile::JsxPrecompile::new(
         options.jsx_import_source.clone().unwrap_or_default(),
         options.jsx_development,
-        None
       )),
       options.jsx_import_source.is_some()
         && !options.transform_jsx

--- a/src/transpiling/mod.rs
+++ b/src/transpiling/mod.rs
@@ -32,6 +32,7 @@ use crate::ParsedSource;
 
 use std::cell::RefCell;
 
+mod jsx_string;
 mod transforms;
 
 #[derive(Debug, Clone, Hash)]

--- a/src/transpiling/mod.rs
+++ b/src/transpiling/mod.rs
@@ -1121,10 +1121,12 @@ for (let i = 0; i < testVariable >> 1; i++) callCount++;
       scope_analysis: false,
     })
     .unwrap();
-    let mut options = EmitOptions::default();
-    options.transform_jsx = false;
-    options.precompile_jsx = true;
-    options.jsx_import_source = Some("react".to_string());
+    let mut options = EmitOptions {
+      transform_jsx: false,
+      precompile_jsx: true,
+      jsx_import_source: Some("react".to_string()),
+      ..Default::default()
+    };
     let code = module.transpile(&options).unwrap().text;
     let expected1 = r#"import { jsx as _jsx, jsxssr as _jsxssr } from "react/jsx-runtime";
 const $$_tpl_1 = [


### PR DESCRIPTION
This PR introduces a new JSX transform that is optimized for server-side rendering. It works by serializing the static parts of a JSX template into static string arrays at compile time. Common JSX templates render around 200-500 nodes in total and the transform in this PR changes the problem from an object allocation to string concatenation one. The latter is around 7-20x faster depending on the amount of static bits inside a template. For the dynamic parts, this transform falls back to the `automatic` runtime one internally.

## Quick JSX history

Traditionally, JSX leaned quite heavily on the Garbage Collector because of its heritage as a templating engine for in-browser rendering.

```tsx
// input
const a = <div className="foo" tabIndex={-1}>hello<span /></div>

// classic Transform
const a = React.createElement(
  "div",
  { className: "foo", tabIndex: -1 },
  "hello",
  React.createElement("span", null)
);
```

Every element expands to two object allocations, a number which grows very quickly the more elements you have.

```tsx
const a = {
  type: "div",
  props: {
    className: "foo",
    tabIndex: -1,
    children: [
      "hello",
      {
        type: "span",
        props: null
      }
    ]
  }
}
```

The later introduced `automatic` runtime transform, didn't change that fact and merely brought auto importing the JSX factory function, some special handling of the `key` prop to the table and putting `children` directly into the props object. The main goal of that transform was to improve the developer experience and avoid an internal deopt that most frameworks ran into by having to copy the `children` argument around.

```tsx
// input
const a = <div className="foo" tabIndex={-1}>hello<span /></div>

// automatic Transform
import { jsx } from "react/jsx-runtime";
const a = jsx(
  "div",
  {
    className: "foo",
    tabIndex: -1,
    children: [
      "hello",
      jsx("span", null)
    ]
  }
})
```

...still expands to many objects:

```jsx
const a = {
  type: "div",
  props: {
    className: "foo",
    tabIndex: -1,
    children: [
      "hello",
      {
        type: "span",
        props: null
      }
    ]
  }
}
```

Both transforms are quite allocation heavy and cause a lot of GC pressure. JSX element is at minimum converted into two object allocations and for many frameworks even a third one if they are backed by fiber nodes. This easily leads to +3000 allocations per request.

## Precompiling JSX at transpile time

The proposed transform in this PR moves all that work to transpilation time and pre-serializes all the static bits of the JSX template.

```tsx
// input
const a = <div className="foo" tabIndex={-1}>hello<span /></div>

// this PR
import { jsxssr, jsxattr } from "react/jsx-runtime";

const tpl = ['<div class="foo" ', '>hello<span></span></div>']
const a = jsxssr(tpl, jsxattr('tabindex', -1));
```

The `jsxssr` function can be thought of as a tagged template literal. It has very similar semantics around concatenating an array of static strings with dynamic content. To note here is that the `className` has been automatically transformed to `class`, same for `tabIndex` -> `tabindex`. Instead of creating thousands of short lived objects, the `jsxssr` function essentially just calls `Array.join()` conceptually. Only the output string is allocation, which makes this very fast.

## Benchmarks

I've put this transform through the tests in a benchmark. The first is the `automatic` transform with Preact, second is the transform from this PR rendered by Preact and third is a custom HTML transform that skips component instances entirely. The latter is obviously the fastest, as component instances are quite heavy too, and currently those need to be instantiated for backwards compatibility reasons in Preact.

- precompiled Preact: **~7.5x faster**
- fully precompiled HTML: **~20x faster**

<img width="1062" alt="Screenshot 2023-10-20 at 20 26 34" src="https://github.com/denoland/deno_ast/assets/1062408/748da013-e78b-4122-8ab5-c09a119e71ce">

## Usefulness for the ecosystem

The transform in this PR was intentionally designed in a way that makes it independent of any framework. It's not tied to Preact or Fresh at all. Rather, by setting a custom `jsxImportSource` config in `deno.json` you can point it to your own factory functions. Each factory function needs to implement the following functions:

- `jsx(type: Function, props: Record<string, unknown>, key?: unknown)` the `automatic` runtime jsx factory for dynamic elements or components.
- `jsxssr(tpl: string[], ...dynamicParts: unknown[])` the main templating function which merges the static bits and with the dynamic bits
- `jsxattr(name: string, value: unknown)` used to serialize dynamic attributes when an element can be serialized. By using a function call frameworks can also return an empty string for event listeners for example and avoid them being serialized

Note: That custom implementations don't have to adhere to specific return values. The transform only expects a certain signature, so if you can also use it for frameworks which don't need to materialize component instances.

If you're interested in more of the transpilation output, checkout the tests.