### PR TITLE
fix: non-identifier properties not quoted

### DIFF
--- a/src/transpiling/jsx_precompile.rs
+++ b/src/transpiling/jsx_precompile.rs
@@ -520,7 +520,15 @@ impl JsxPrecompile {
         match attr {
           JSXAttrOrSpread::JSXAttr(jsx_attr) => {
             let attr_name = get_attr_name(jsx_attr, is_component);
-            let prop_name = PropName::Ident(quote_ident!(attr_name.clone()));
+            let prop_name = if attr_name.contains('-') {
+              PropName::Str(Str {
+                span: DUMMY_SP,
+                raw: None,
+                value: attr_name.clone().into(),
+              })
+            } else {
+              PropName::Ident(quote_ident!(attr_name.clone()))
+            };
 
             // Case: <Foo required />
             let Some(attr_value) = &jsx_attr.value else {
@@ -1181,6 +1189,11 @@ const a = _jsxssr($$_tpl_1);"#,
         .as_str(),
       );
 
+      let quoted = if mapping.1.contains('-') {
+        format!("\"{}\"", &mapping.1)
+      } else {
+        mapping.1.clone()
+      };
       // should still be normalized if HTML element cannot
       // be serialized
       test_transform(
@@ -1189,7 +1202,7 @@ const a = _jsxssr($$_tpl_1);"#,
           .as_str(),
         format!(
           "{}\nconst a = _jsx(\"label\", {{\n  {}: \"foo\",\n  ...foo\n}});",
-          "import { jsx as _jsx } from \"react/jsx-runtime\";", &mapping.1
+          "import { jsx as _jsx } from \"react/jsx-runtime\";", quoted
         )
         .as_str(),
       );
@@ -1282,6 +1295,19 @@ const a = _jsx("div", {
   ...props,
   bar: "2",
   children: "foo"
+});"#,
+    );
+  }
+
+  #[test]
+  fn non_identiifer_attr_test() {
+    test_transform(
+      JsxPrecompile::default(),
+      r#"const a = <Foo aria-label="bar" {...props} />;"#,
+      r#"import { jsx as _jsx } from "react/jsx-runtime";
+const a = _jsx(Foo, {
+  "aria-label": "bar",
+  ...props
 });"#,
     );
   }


### PR DESCRIPTION
Ran into a bug where we didn't quote non-identifier object properties like `aria-label`.

```tsx
// before
const a = { aria-label: "foo" }

// after
const a = { "aria-label": "foo" }
```