### PR TITLE
fix: drop unnecessary whitespace

### DIFF
--- a/src/transpiling/jsx_precompile.rs
+++ b/src/transpiling/jsx_precompile.rs
@@ -273,9 +273,9 @@ fn jsx_text_to_str(jsx_text: &JSXText) -> String {
 
     if i > 0 && !text.is_empty() {
       text.push(' ')
-    } else {
-      text.push_str(&line);
     }
+
+    text.push_str(&line);
   }
 
   text
@@ -1506,6 +1506,19 @@ const a = _jsxssr($$_tpl_1);"#,
       r#"import { jsxssr as _jsxssr } from "react/jsx-runtime";
 const $$_tpl_1 = [
   "<p>foo</p>"
+];
+const a = _jsxssr($$_tpl_1);"#,
+    );
+
+    test_transform(
+      JsxPrecompile::default(),
+      r#"const a = <p>
+      foo
+      bar
+</p>;"#,
+      r#"import { jsxssr as _jsxssr } from "react/jsx-runtime";
+const $$_tpl_1 = [
+  "<p>foo bar</p>"
 ];
 const a = _jsxssr($$_tpl_1);"#,
     );

--- a/src/transpiling/jsx_precompile.rs
+++ b/src/transpiling/jsx_precompile.rs
@@ -261,7 +261,7 @@ fn jsx_text_to_str(jsx_text: &JSXText) -> String {
   while let Some((i, line)) = lines.next() {
     let line = if i != 0 {
       line.trim_start_matches(' ')
-    } else if !lines.peek().is_none() {
+    } else if lines.peek().is_some() {
       line.trim_end_matches(' ')
     } else {
       line
@@ -275,7 +275,7 @@ fn jsx_text_to_str(jsx_text: &JSXText) -> String {
       text.push(' ')
     }
 
-    text.push_str(&line);
+    text.push_str(line);
   }
 
   text
@@ -444,7 +444,7 @@ impl JsxPrecompile {
           match child {
             // Case: <div>foo</div>
             JSXElementChild::JSXText(jsx_text) => {
-              let text = jsx_text_to_str(&jsx_text);
+              let text = jsx_text_to_str(jsx_text);
 
               // Text nodes which only contain whitespace can be ignored
               if text.is_empty() {
@@ -736,7 +736,7 @@ impl JsxPrecompile {
       match child {
         // Case: <div>foo</div>
         JSXElementChild::JSXText(jsx_text) => {
-          let text = jsx_text_to_str(&jsx_text);
+          let text = jsx_text_to_str(jsx_text);
 
           // Text nodes which only contain whitespace can be ignored
           if text.is_empty() {

--- a/src/transpiling/jsx_precompile.rs
+++ b/src/transpiling/jsx_precompile.rs
@@ -254,6 +254,33 @@ fn normalize_lit_str(lit: &Lit) -> Lit {
   }
 }
 
+fn jsx_text_to_str(jsx_text: &JSXText) -> String {
+  let mut text = String::new();
+
+  let mut lines = jsx_text.value.lines().enumerate().peekable();
+  while let Some((i, line)) = lines.next() {
+    let line = if i != 0 {
+      line.trim_start_matches(' ')
+    } else if !lines.peek().is_none() {
+      line.trim_end_matches(' ')
+    } else {
+      line
+    };
+
+    if line.is_empty() {
+      continue;
+    }
+
+    if i > 0 && !text.is_empty() {
+      text.push(' ')
+    } else {
+      text.push_str(&line);
+    }
+  }
+
+  text
+}
+
 /// Convert a JSXMemberExpr to MemberExpr. We offload this to a
 /// function because conversion is recursive.
 fn jsx_member_expr_to_normal(jsx_member_expr: &JSXMemberExpr) -> MemberExpr {
@@ -417,9 +444,16 @@ impl JsxPrecompile {
           match child {
             // Case: <div>foo</div>
             JSXElementChild::JSXText(jsx_text) => {
+              let text = jsx_text_to_str(&jsx_text);
+
+              // Text nodes which only contain whitespace can be ignored
+              if text.is_empty() {
+                continue;
+              }
+
               elems.push(Some(ExprOrSpread {
                 spread: None,
-                expr: Box::new(string_lit_expr(jsx_text.value.to_string())),
+                expr: Box::new(string_lit_expr(text)),
               }));
             }
             // Case: <div>{2 + 2}</div>
@@ -469,6 +503,15 @@ impl JsxPrecompile {
             // transform supports it. Babel and TypeScript error when they
             // encounter this.
             JSXElementChild::JSXSpreadChild(_) => {}
+          }
+        }
+
+        // Flatten to a single child call when children
+        // array only contains one element
+        if elems.len() == 1 {
+          if let Some(first) = &elems[0] {
+            let expr = &*first.expr;
+            return Some(expr.clone());
           }
         }
 
@@ -693,7 +736,14 @@ impl JsxPrecompile {
       match child {
         // Case: <div>foo</div>
         JSXElementChild::JSXText(jsx_text) => {
-          let escaped_text = escape_html(jsx_text.value.as_ref());
+          let text = jsx_text_to_str(&jsx_text);
+
+          // Text nodes which only contain whitespace can be ignored
+          if text.is_empty() {
+            continue;
+          }
+
+          let escaped_text = escape_html(text.as_ref());
           strings.last_mut().unwrap().push_str(escaped_text.as_str());
         }
         // Case: <div>{2 + 2}</div>
@@ -1443,6 +1493,47 @@ const $$_tpl_1 = [
   "<p></p>"
 ];
 const a = _jsxssr($$_tpl_1);"#,
+    );
+  }
+
+  #[test]
+  fn empty_jsx_text_children_test() {
+    test_transform(
+      JsxPrecompile::default(),
+      r#"const a = <p>
+      foo
+</p>;"#,
+      r#"import { jsxssr as _jsxssr } from "react/jsx-runtime";
+const $$_tpl_1 = [
+  "<p>foo</p>"
+];
+const a = _jsxssr($$_tpl_1);"#,
+    );
+
+    test_transform(
+      JsxPrecompile::default(),
+      r#"const a = <p>
+  <span />
+</p>;"#,
+      r#"import { jsxssr as _jsxssr } from "react/jsx-runtime";
+const $$_tpl_1 = [
+  "<p><span></span></p>"
+];
+const a = _jsxssr($$_tpl_1);"#,
+    );
+
+    test_transform(
+      JsxPrecompile::default(),
+      r#"const a = <Foo>
+  <span />
+</Foo>;"#,
+      r#"import { jsx as _jsx, jsxssr as _jsxssr } from "react/jsx-runtime";
+const $$_tpl_1 = [
+  "<span></span>"
+];
+const a = _jsx(Foo, {
+  children: _jsxssr($$_tpl_1)
+});"#,
     );
   }
 


### PR DESCRIPTION
Similar to text nodes in HTML, JSXText nodes that have surrounding whitespace can be trimmed in most scenarios. This makes the compilation output cleaner and allows us to flatten children arrays if only a single child remained after dropping unnecessary nodes.

Before: 

```jsx
 _jsxssr($$_tpl_1, _jsx(Head, {
    children: [
      "\n\n        ",
      _jsxssr($$_tpl_2),
      "\n\n        ",
      _jsxssr($$_tpl_3),
      "\n\n        ",
      _jsxssr($$_tpl_4),
      "\n\n        ",
      _jsxssr($$_tpl_5),
      "\n\n\n\n        ",
      "\n\n        ",
      _jsxssr($$_tpl_6),
      "\n\n\n\n        ",
      _jsxssr($$_tpl_7),
      "\n\n        ",
      _jsxssr($$_tpl_8),
      "\n\n      "
    ]
  })
```

After

```jsx
 _jsxssr($$_tpl_1, _jsx(Head, {
    children: [
      _jsxssr($$_tpl_2),
      _jsxssr($$_tpl_3),
      _jsxssr($$_tpl_4),
      _jsxssr($$_tpl_5),
      _jsxssr($$_tpl_6),
      _jsxssr($$_tpl_7),
      _jsxssr($$_tpl_8)
    ]
  })
```