### PR TITLE
feat: serialize numeric jsx attribute values

### DIFF
--- a/src/transpiling/jsx_precompile.rs
+++ b/src/transpiling/jsx_precompile.rs
@@ -364,11 +364,7 @@ fn escape_html(str: &str) -> String {
 }
 
 fn serialize_attr(attr_name: &str, value: &str) -> String {
-  format!(
-    " {}=\"{}\"",
-    escape_html(&attr_name).as_str(),
-    escape_html(&value)
-  )
+  format!(" {}=\"{}\"", escape_html(attr_name), escape_html(value))
 }
 
 impl JsxPrecompile {
@@ -871,7 +867,7 @@ impl JsxPrecompile {
                 }
 
                 let serialized_attr =
-                  serialize_attr(&attr_name, &string_lit.value.as_ref());
+                  serialize_attr(&attr_name, &string_lit.value);
 
                 strings
                   .last_mut()

--- a/src/transpiling/jsx_precompile.rs
+++ b/src/transpiling/jsx_precompile.rs
@@ -891,20 +891,18 @@ impl JsxPrecompile {
 
                   // Serialize numeric literal values
                   // Case: <img width={100} />
-                  if let Expr::Lit(lit) = &expr {
-                    if let Lit::Num(num) = lit {
-                      let serialized_attr = format!(
-                        " {}=\"{}\"",
-                        escape_html(&attr_name).as_str(),
-                        &num.value
-                      );
+                  if let Expr::Lit(Lit::Num(num)) = &expr {
+                    let serialized_attr = format!(
+                      " {}=\"{}\"",
+                      escape_html(&attr_name).as_str(),
+                      &num.value
+                    );
 
-                      strings
-                        .last_mut()
-                        .unwrap()
-                        .push_str(serialized_attr.as_str());
-                      continue;
-                    }
+                    strings
+                      .last_mut()
+                      .unwrap()
+                      .push_str(serialized_attr.as_str());
+                    continue;
                   }
 
                   strings.last_mut().unwrap().push(' ');


### PR DESCRIPTION
When we encounter a numeric JSX attribute value `<img width={100} />`, we can serialize it ourselves rather than going through `jsxattr()`. This is a minor perf optimization.