### PR TITLE
feat: merge serializable jsx children

### DIFF
--- a/src/transpiling/jsx_precompile.rs
+++ b/src/transpiling/jsx_precompile.rs
@@ -400,7 +400,9 @@ fn merge_serializable_children(
           JSXExpr::Expr(expr) => {
             if let Expr::Lit(lit) = *expr.clone() {
               match lit {
-                // Booleans are not rendered
+                // Booleans are not rendered because people usually use
+                // them for conditional rendering.
+                // Case <div>{foo && <span />}</div>
                 Lit::Bool(_) => continue,
                 // Can be flattened
                 Lit::Num(num) => {

--- a/src/transpiling/jsx_precompile.rs
+++ b/src/transpiling/jsx_precompile.rs
@@ -598,7 +598,7 @@ impl JsxPrecompile {
         } else {
           // Here we parse children the normal way
 
-          for child in normalized_children.iter() {
+          for child in normalized_children {
             match child {
               // Case: <div>foo</div>
               JSXElementChild::JSXText(jsx_text) => {
@@ -624,7 +624,7 @@ impl JsxPrecompile {
               }
               // Case: <div><span /></div>
               JSXElementChild::JSXElement(jsx_el) => {
-                let expr = self.serialize_jsx(jsx_el);
+                let expr = self.serialize_jsx(&*jsx_el);
                 elems.push(Some(ExprOrSpread {
                   spread: None,
                   expr: Box::new(expr.clone()),
@@ -887,7 +887,7 @@ impl JsxPrecompile {
     let (normalized_children, _text_count, _serializable_count) =
       merge_serializable_children(children);
 
-    for child in normalized_children.iter() {
+    for child in normalized_children {
       match child {
         // Case: <div>foo</div>
         JSXElementChild::JSXText(jsx_text) => {
@@ -913,7 +913,7 @@ impl JsxPrecompile {
         // Case: <div><span /></div>
         JSXElementChild::JSXElement(jsx_element) => self
           .serialize_jsx_element_to_string_vec(
-            jsx_element,
+            &*jsx_element,
             strings,
             dynamic_exprs,
           ),

--- a/src/transpiling/jsx_precompile.rs
+++ b/src/transpiling/jsx_precompile.rs
@@ -568,11 +568,6 @@ impl JsxPrecompile {
           buf = String::new()
         }
 
-        eprintln!(
-          "text {:#?}, seri: {:#?} non: {}",
-          text_count, serializable_count, non_serializable_count
-        );
-
         // Merge sibling children when they can be serialized into one
         // serialized child. If all children are serializable, we'll
         // merge everything into one big jsxssr() call. If everything

--- a/src/transpiling/jsx_precompile.rs
+++ b/src/transpiling/jsx_precompile.rs
@@ -637,9 +637,7 @@ impl JsxPrecompile {
                 {
                   match child_expr {
                     Expr::Array(array_lit) => {
-                      for item in array_lit.elems.iter() {
-                        elems.push(item.clone());
-                      }
+                      elems.extend(array_lit.elems);
                     }
                     _ => {
                       elems.push(Some(ExprOrSpread {

--- a/src/transpiling/jsx_precompile.rs
+++ b/src/transpiling/jsx_precompile.rs
@@ -372,11 +372,7 @@ fn merge_serializable_children(
   children: &Vec<JSXElementChild>,
 ) -> (Vec<JSXElementChild>, usize, usize) {
   // Do a first pass over children to merge sibling text nodes
-  // and check if it contains any serializable nodes. If it
-  // contains multiple serializable nodes or one and at least
-  // one text node, we can wrap the whole children with a static
-  // template. If not, then we need to create an array literal.
-  // Case: <Foo>foo{" "}</Foo
+  // and check if it contains any serializable nodes.
   let mut text_count = 0;
   let mut serializable_count = 0;
   let mut buf = String::new();
@@ -404,8 +400,7 @@ fn merge_serializable_children(
           JSXExpr::Expr(expr) => {
             if let Expr::Lit(lit) = *expr.clone() {
               match lit {
-                // These are not rendered
-                Lit::Null(_) => continue,
+                // Booleans are not rendered
                 Lit::Bool(_) => continue,
                 // Can be flattened
                 Lit::Num(num) => {
@@ -2206,7 +2201,7 @@ const a = _jsx(Foo, {
 
     test_transform(
       JsxPrecompile::default(),
-      r#"const a = <Foo>foo{2}bar{null}{true}{false}baz</Foo>"#,
+      r#"const a = <Foo>foo{2}bar{true}{false}baz</Foo>"#,
       r#"import { jsx as _jsx } from "react/jsx-runtime";
 const a = _jsx(Foo, {
   children: "foo2barbaz"

--- a/src/transpiling/jsx_precompile.rs
+++ b/src/transpiling/jsx_precompile.rs
@@ -369,7 +369,7 @@ fn serialize_attr(attr_name: &str, value: &str) -> String {
 }
 
 fn merge_serializable_children(
-  children: &Vec<JSXElementChild>,
+  children: &[JSXElementChild],
 ) -> (Vec<JSXElementChild>, usize, usize) {
   // Do a first pass over children to merge sibling text nodes
   // and check if it contains any serializable nodes.
@@ -381,7 +381,7 @@ fn merge_serializable_children(
   for child in children.iter() {
     match child {
       JSXElementChild::JSXText(jsx_text) => {
-        let text = jsx_text_to_str(&jsx_text);
+        let text = jsx_text_to_str(jsx_text);
         if text.is_empty() {
           continue;
         }
@@ -880,7 +880,7 @@ impl JsxPrecompile {
 
   fn serialize_jsx_children_to_string(
     &mut self,
-    children: &Vec<JSXElementChild>,
+    children: &[JSXElementChild],
     strings: &mut Vec<String>,
     dynamic_exprs: &mut Vec<Expr>,
   ) {

--- a/src/transpiling/jsx_precompile.rs
+++ b/src/transpiling/jsx_precompile.rs
@@ -624,7 +624,7 @@ impl JsxPrecompile {
               }
               // Case: <div><span /></div>
               JSXElementChild::JSXElement(jsx_el) => {
-                let expr = self.serialize_jsx(&*jsx_el);
+                let expr = self.serialize_jsx(&jsx_el);
                 elems.push(Some(ExprOrSpread {
                   spread: None,
                   expr: Box::new(expr.clone()),
@@ -911,7 +911,7 @@ impl JsxPrecompile {
         // Case: <div><span /></div>
         JSXElementChild::JSXElement(jsx_element) => self
           .serialize_jsx_element_to_string_vec(
-            &*jsx_element,
+            &jsx_element,
             strings,
             dynamic_exprs,
           ),

--- a/src/transpiling/jsx_precompile.rs
+++ b/src/transpiling/jsx_precompile.rs
@@ -614,10 +614,7 @@ impl JsxPrecompile {
                   // Case: <div>{/* some comment */}</div>
                   JSXExpr::JSXEmptyExpr(_) => continue,
                   JSXExpr::Expr(expr) => {
-                    elems.push(Some(ExprOrSpread {
-                      spread: None,
-                      expr,
-                    }));
+                    elems.push(Some(ExprOrSpread { spread: None, expr }));
                   }
                 }
               }

--- a/src/transpiling/mod.rs
+++ b/src/transpiling/mod.rs
@@ -1147,20 +1147,17 @@ for (let i = 0; i < testVariable >> 1; i++) callCount++;
     };
     let code = module.transpile(&options).unwrap().text;
     let expected1 = r#"import { jsx as _jsx, jsxssr as _jsxssr } from "react/jsx-runtime";
-const $$_tpl_1 = [
-  "<span>hello</span>"
-];
 const $$_tpl_2 = [
   "<p>asdf</p>"
 ];
+const $$_tpl_1 = [
+  "<span>hello</span>foo",
+  ""
+];
 const a = _jsx(Foo, {
-  children: [
-    _jsxssr($$_tpl_1),
-    "foo",
-    _jsx(Bar, {
-      children: _jsxssr($$_tpl_2)
-    })
-  ]
+  children: _jsxssr($$_tpl_1, _jsx(Bar, {
+    children: _jsxssr($$_tpl_2)
+  }))
 });
 //# sourceMappingURL=data:application/json;base64,eyJ2ZXJza"#;
     assert_eq!(&code[0..expected1.len()], expected1);
@@ -1168,20 +1165,17 @@ const a = _jsx(Foo, {
     options.jsx_development = true;
     let code = module.transpile(&options).unwrap().text;
     let expected2 = r#"import { jsxDEV as _jsxDEV, jsxssr as _jsxssr } from "react/jsx-dev-runtime";
-const $$_tpl_1 = [
-  "<span>hello</span>"
-];
 const $$_tpl_2 = [
   "<p>asdf</p>"
 ];
+const $$_tpl_1 = [
+  "<span>hello</span>foo",
+  ""
+];
 const a = _jsxDEV(Foo, {
-  children: [
-    _jsxssr($$_tpl_1),
-    "foo",
-    _jsxDEV(Bar, {
-      children: _jsxssr($$_tpl_2)
-    })
-  ]
+  children: _jsxssr($$_tpl_1, _jsxDEV(Bar, {
+    children: _jsxssr($$_tpl_2)
+  }))
 });
 //# sourceMappingURL=data:application/json;base64,eyJ2ZXJza"#;
     assert_eq!(&code[0..expected2.len()], expected2);


### PR DESCRIPTION
This PR adds some logic to the new JSX transforms that allows it to merge serializable JSX children together. A node is deemed serializable when it is text, or is a serializable HTML node. This addresses the following scenarios where we'd generate more templates than necessary:

```jsx
// input
<div>foo{" "}bar</div>

// before
const tpl = [
  "<div>foo",
  "",
  "bar</div>"
]
jsxssr(tpl, " ")

// after
const tpl = [
  "<div>foo bar</div>",
]
jsxssr(tpl)
```

This scenario happens often enough in our code bases that this optimization should be worth it.