### PR TITLE
fix: jsx templates added before imports

### DIFF
--- a/src/transpiling/jsx_precompile.rs
+++ b/src/transpiling/jsx_precompile.rs
@@ -1222,14 +1222,10 @@ impl VisitMut for JsxPrecompile {
       .body
       .iter()
       .position(|stmt| match stmt {
-        ModuleItem::ModuleDecl(mod_dec) => match mod_dec {
-          ModuleDecl::ExportDecl(_) => true,
-          _ => false,
-        },
-        ModuleItem::Stmt(stmt) => match stmt {
-          Stmt::Empty(_) => false,
-          _ => true,
-        },
+        ModuleItem::ModuleDecl(mod_dec) => {
+          matches!(mod_dec, ModuleDecl::ExportDecl(_))
+        }
+        ModuleItem::Stmt(stmt) => !matches!(stmt, Stmt::Empty(_)),
       })
       .unwrap_or(0);
 


### PR DESCRIPTION
Noticed a case where we were still adding JSX templates before an import statement. Our heuristic wasn't sufficient and didn't take empty statements or export declarations into account.