### PR TITLE
fix: jsx templates added before imports

### DIFF
--- a/src/transpiling/jsx_precompile.rs
+++ b/src/transpiling/jsx_precompile.rs
@@ -1275,7 +1275,10 @@ impl VisitMut for JsxPrecompile {
       .iter()
       .position(|stmt| match stmt {
         ModuleItem::ModuleDecl(mod_dec) => {
-          matches!(mod_dec, ModuleDecl::ExportDecl(_))
+          matches!(
+            mod_dec,
+            ModuleDecl::ExportDecl(_) | ModuleDecl::ExportDefaultDecl(_)
+          )
         }
         ModuleItem::Stmt(stmt) => !matches!(stmt, Stmt::Empty(_)),
       })
@@ -2250,6 +2253,23 @@ const $$_tpl_1 = [
   "<div></div>"
 ];
 export function foo() {
+  return _jsxssr($$_tpl_1);
+}"#,
+    );
+
+    test_transform(
+      JsxPrecompile::default(),
+      r#"import Foo from "./foo.ts";
+
+export default function foo() {
+  return <div />
+}"#,
+      r#"import { jsxssr as _jsxssr } from "react/jsx-runtime";
+import Foo from "./foo.ts";
+const $$_tpl_1 = [
+  "<div></div>"
+];
+export default function foo() {
   return _jsxssr($$_tpl_1);
 }"#,
     );


### PR DESCRIPTION
I missed a case where the JSX templates would be added before imports in https://github.com/denoland/deno_ast/pull/175 