### PR TITLE
feat: jsx ensure dynamic values are escaped

### DIFF
--- a/src/transpiling/jsx_precompile.rs
+++ b/src/transpiling/jsx_precompile.rs
@@ -27,7 +27,7 @@ pub struct JsxPrecompile {
   // Track if we need to import `jsxAttr` and which identifier
   // to use if we do.
   import_jsx_attr: Option<Ident>,
-  // Track if we need to import `escape` and which identifier
+  // Track if we need to import `jsxEscape` and which identifier
   // to use if we do.
   import_jsx_escape: Option<Ident>,
 }
@@ -553,7 +553,7 @@ impl JsxPrecompile {
     }
   }
 
-  /// Mark `escape` as being used and return the identifier.
+  /// Mark `jsxEscape` as being used and return the identifier.
   fn get_jsx_escape_fn_identifier(&mut self) -> Ident {
     match &self.import_jsx_escape {
       Some(ident) => ident.clone(),

--- a/src/transpiling/jsx_precompile.rs
+++ b/src/transpiling/jsx_precompile.rs
@@ -591,8 +591,8 @@ impl JsxPrecompile {
         Lit::Bool(_) => expr,
         Lit::Null(_) => expr,
         Lit::Str(string_lit) => {
-          let escaped_value = escape_html(&string_lit.value.to_string());
-          if escaped_value != string_lit.value.to_string() {
+          let escaped_value = escape_html(string_lit.value.as_ref());
+          if string_lit.value != escaped_value {
             self.wrap_with_escape_call(expr)
           } else {
             expr

--- a/src/transpiling/jsx_precompile.rs
+++ b/src/transpiling/jsx_precompile.rs
@@ -1292,11 +1292,8 @@ impl JsxPrecompile {
       ))
     }
 
-    if let Some(espace_ident) = &self.import_jsx_escape {
-      imports.push((
-        espace_ident.clone(),
-        Ident::new("jsxEscape".into(), DUMMY_SP),
-      ))
+    if let Some(espace_ident) = self.import_jsx_escape.take() {
+      imports.push((espace_ident, Ident::new("jsxEscape".into(), DUMMY_SP)))
     }
 
     if !imports.is_empty() {

--- a/src/transpiling/jsx_precompile.rs
+++ b/src/transpiling/jsx_precompile.rs
@@ -1414,7 +1414,7 @@ impl VisitMut for JsxPrecompile {
           let child = &frag.children[0];
           match child {
             JSXElementChild::JSXText(jsx_text) => {
-              let text = jsx_text_to_str(&jsx_text);
+              let text = jsx_text_to_str(jsx_text);
               *expr = string_lit_expr(text.into())
             }
             JSXElementChild::JSXExprContainer(jsx_expr_container) => {

--- a/src/transpiling/jsx_precompile.rs
+++ b/src/transpiling/jsx_precompile.rs
@@ -585,7 +585,7 @@ impl JsxPrecompile {
   /// If we have a string literal and know that it doesn't need
   /// to be encoded we can skip the escape call.
   fn maybe_wrap_with_jsx_escape_call(&mut self, expr: Expr) -> Expr {
-    match expr.clone() {
+    match &expr {
       Expr::Lit(lit_expr) => match lit_expr {
         Lit::Num(_) => expr,
         Lit::Bool(_) => expr,

--- a/src/transpiling/jsx_precompile.rs
+++ b/src/transpiling/jsx_precompile.rs
@@ -1817,17 +1817,6 @@ const $$_tpl_1 = [
 ];
 const a = _jsxTemplate($$_tpl_1);"#,
     );
-
-    test_transform(
-      JsxPrecompile::default(),
-      r#"const a = <div class={foo}>foo</div>;"#,
-      r#"import { jsxTemplate as _jsxTemplate, jsxAttr as _jsxAttr } from "react/jsx-runtime";
-const $$_tpl_1 = [
-  "<div ",
-  ">foo</div>"
-];
-const a = _jsxTemplate($$_tpl_1, _jsxAttr("class", foo));"#,
-    );
   }
 
   #[test]


### PR DESCRIPTION
When we receive a dynamic value that we cannot analyze statically we need to ensure that it is escaped properly before processing it. This PR adds a new `jsxEscape()` function from the jsx runtime to support that.

The reason the new transform is fast is because it only concerns itself with concatenating strings together. To make this work efficiently `jsxssr` expects values to be pre-escaped. This is necessary to make `jsxattr` performant, otherwise you'd need to allocate the full props object again.

 ```jsx
 // input
 <div>{foo}</div>
 
 // out
 jsxssr(tpl, jsxEscape(foo))
 ```