### PR TITLE
fix: drop development for precompile JSX transform

### DIFF
--- a/src/transpiling/mod.rs
+++ b/src/transpiling/mod.rs
@@ -319,7 +319,6 @@ pub fn fold_program(
     Optional::new(
       as_folder(jsx_precompile::JsxPrecompile::new(
         options.jsx_import_source.clone().unwrap_or_default(),
-        options.jsx_development,
       )),
       options.jsx_import_source.is_some()
         && !options.transform_jsx
@@ -1139,7 +1138,7 @@ for (let i = 0; i < testVariable >> 1; i++) callCount++;
       scope_analysis: false,
     })
     .unwrap();
-    let mut options = EmitOptions {
+    let options = EmitOptions {
       transform_jsx: false,
       precompile_jsx: true,
       jsx_import_source: Some("react".to_string()),
@@ -1161,23 +1160,5 @@ const a = _jsx(Foo, {
 });
 //# sourceMappingURL=data:application/json;base64,eyJ2ZXJza"#;
     assert_eq!(&code[0..expected1.len()], expected1);
-
-    options.jsx_development = true;
-    let code = module.transpile(&options).unwrap().text;
-    let expected2 = r#"import { jsxDEV as _jsxDEV, jsxssr as _jsxssr } from "react/jsx-dev-runtime";
-const $$_tpl_2 = [
-  "<p>asdf</p>"
-];
-const $$_tpl_1 = [
-  "<span>hello</span>foo",
-  ""
-];
-const a = _jsxDEV(Foo, {
-  children: _jsxssr($$_tpl_1, _jsxDEV(Bar, {
-    children: _jsxssr($$_tpl_2)
-  }))
-});
-//# sourceMappingURL=data:application/json;base64,eyJ2ZXJza"#;
-    assert_eq!(&code[0..expected2.len()], expected2);
   }
 }


### PR DESCRIPTION
Currently, this transform doesn't really have a `development` behavior really. Exposing this in the transform options is therefore confusing.

What we did when `development: true` is that we imported from `jsx-dev-runtime` and called `jsxDEV` instead of `jsx`, but that has been more or less regarded as a design flaw of the jsx runtime proposal. These days everyone just aliases `jsx-dev-runtime` and `jsx-runtime` to the exact same file and aliases `jsxDEV` to `jsx`. The only difference between those functions is that `jsxDEV` receives more parameters about call location. Everyone just treats that as optional arguments to `jsx` these days.

For all those reasons it's best if we drop the `development` option of the precompile transform.