### PR TITLE
0.31.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,7 +192,7 @@ dependencies = [
 
 [[package]]
 name = "deno_ast"
-version = "0.32.0"
+version = "0.31.2"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deno_ast"
-version = "0.32.0"
+version = "0.31.2"
 authors = ["the Deno authors"]
 documentation = "https://docs.rs/deno_ast"
 edition = "2021"


### PR DESCRIPTION
I cancelled the 0.32.0 publish because if we do a patch release then we'll only have to bump in Deno and not any of the intermediary crates. There hasn't been any public api changes and nobody is using the jsx feature yet so this should be ok.