### PR TITLE
chore: add script for automatically updating swc dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,4 +35,4 @@ jobs:
         run: |
           git config user.email "denobot@users.noreply.github.com"
           git config user.name "denobot"
-          deno run -A https://raw.githubusercontent.com/denoland/automation/0.15.0/tasks/publish_release.ts --${{github.event.inputs.releaseKind}}
+          deno run -A https://raw.githubusercontent.com/denoland/automation/0.20.0/tasks/publish_release.ts --${{github.event.inputs.releaseKind}}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,8 @@ url = { version = "2.3.1", features = ["serde"], optional = true }
 # swc's version bumping is very buggy and there will often be patch versions
 # published that break our build, so we pin all swc versions to prevent
 # pulling in new versions of swc crates
+#
+# NOTE: You can automatically update these dependencies by running ./scripts/update_swc_deps.ts
 swc_atoms = "=0.6.4"
 swc_common = "=0.33.9"
 swc_config = { version = "=0.1.7", optional = true }

--- a/deno.json
+++ b/deno.json
@@ -1,14 +1,6 @@
 {
   "lock": false,
-  "fmt": {
-    "include": [
-      "./README.md",
-      "./scripts"
-    ]
-  },
-  "lint": {
-    "include": [
-      "./scripts"
-    ]
-  }
+  "exclude": [
+    "target"
+  ]
 }

--- a/scripts/deps.ts
+++ b/scripts/deps.ts
@@ -1,3 +1,3 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
-export * from "https://raw.githubusercontent.com/denoland/automation/0.19.2/mod.ts";
+export * from "https://raw.githubusercontent.com/denoland/automation/0.20.0/mod.ts";

--- a/scripts/repos.ts
+++ b/scripts/repos.ts
@@ -2,9 +2,7 @@
 
 import { $, Crate, Repo } from "./deps.ts";
 
-export const rootDir = $.path.resolve(
-  $.path.join($.path.fromFileUrl(import.meta.url), "../../../../"),
-);
+export const rootDir = $.path(import.meta).join("../../../").resolve();
 
 const repoNames = [
   "deno_ast",
@@ -42,7 +40,7 @@ export class Repos {
     function loadRepo(name: string) {
       return Repo.load({
         name,
-        path: $.path.join(rootDir, name),
+        path: rootDir.join(name),
         skipLoadingCrates,
       }).catch((err) => {
         console.error(`Error loading: ${name}`);

--- a/scripts/update_swc_deps.ts
+++ b/scripts/update_swc_deps.ts
@@ -8,7 +8,9 @@ const repo = await Repo.load({
 });
 
 const crate = repo.getCrate("deno_ast");
-const swcDeps = crate.dependencies.filter(dep => dep.name.startsWith("swc_") || dep.name === "dprint-swc-ext");
+const swcDeps = crate.dependencies.filter((dep) =>
+  dep.name.startsWith("swc_") || dep.name === "dprint-swc-ext"
+);
 for (const dep of swcDeps) {
   const version = await Crate.getLatestVersion(dep.name);
   if (version == null) {

--- a/scripts/update_swc_deps.ts
+++ b/scripts/update_swc_deps.ts
@@ -17,7 +17,7 @@ for (const dep of swcDeps) {
     throw new Error(`Could not find latest version for ${dep.name}`);
   }
 
-  const newReq = dep.name === "dprint-swc-ext" ? version : "=" + version;
+  const newReq = dep.name === "dprint-swc-ext" ? "^" + version : "=" + version;
   if (newReq !== dep.req) {
     $.logStep("Updating", dep.name, "from", dep.req, "to", newReq);
     crate.setDependencyVersion(dep.name, newReq);

--- a/scripts/update_swc_deps.ts
+++ b/scripts/update_swc_deps.ts
@@ -20,6 +20,6 @@ for (const dep of swcDeps) {
   const newReq = dep.name === "dprint-swc-ext" ? "^" + version : "=" + version;
   if (newReq !== dep.req) {
     $.logStep("Updating", dep.name, "from", dep.req, "to", newReq);
-    crate.setDependencyVersion(dep.name, newReq);
+    crate.setDependencyVersion(dep.name, newReq.replace(/^\^/, ""));
   }
 }

--- a/scripts/update_swc_deps.ts
+++ b/scripts/update_swc_deps.ts
@@ -1,0 +1,23 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+import { $, Crate, Repo } from "./deps.ts";
+
+const repo = await Repo.load({
+  name: "deno_ast",
+  path: $.path(import.meta).parentOrThrow().parentOrThrow().resolve(),
+});
+
+const crate = repo.getCrate("deno_ast");
+const swcDeps = crate.dependencies.filter(dep => dep.name.startsWith("swc_") || dep.name === "dprint-swc-ext");
+for (const dep of swcDeps) {
+  const version = await Crate.getLatestVersion(dep.name);
+  if (version == null) {
+    throw new Error(`Could not find latest version for ${dep.name}`);
+  }
+
+  const newReq = dep.name === "dprint-swc-ext" ? version : "=" + version;
+  if (newReq !== dep.req) {
+    $.logStep("Updating", dep.name, "from", dep.req, "to", newReq);
+    crate.setDependencyVersion(dep.name, newReq);
+  }
+}


### PR DESCRIPTION
Adds a script that automatically updates the Cargo.toml with the latest deps. I got tired of manually doing this.