### PR TITLE
feat: expose analyzing deps without a ParsedSource and improvements to Comments

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,6 @@ on:
     inputs:
       releaseKind:
         description: 'Kind of release'
-        default: 'minor'
         type: choice
         options:
           - patch

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.73.0"
+channel = "1.74.1"
 components = ["clippy", "rustfmt"]
 profile = "minimal"

--- a/src/comments.rs
+++ b/src/comments.rs
@@ -10,6 +10,7 @@ use crate::swc::common::comments::SingleThreadedComments;
 use crate::swc::common::comments::SingleThreadedCommentsMapInner;
 use crate::swc::common::BytePos as SwcBytePos;
 use crate::SourcePos;
+
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -63,16 +64,19 @@ impl MultiThreadedComments {
 
   /// Gets a vector of all the comments sorted by position.
   pub fn get_vec(&self) -> Vec<Comment> {
-    let mut comments = self
+    let mut comments = self.iter_unstable().cloned().collect::<Vec<_>>();
+    comments.sort_by_key(|comment| comment.span.lo);
+    comments
+  }
+
+  /// Iterates through all the comments in an unstable order.
+  pub fn iter_unstable(&self) -> impl Iterator<Item = &Comment> {
+    self
       .inner
       .leading
       .values()
       .chain(self.inner.trailing.values())
       .flatten()
-      .cloned()
-      .collect::<Vec<_>>();
-    comments.sort_by_key(|comment| comment.span.lo);
-    comments
   }
 
   pub fn has_leading(&self, pos: SourcePos) -> bool {

--- a/src/comments.rs
+++ b/src/comments.rs
@@ -36,7 +36,14 @@ impl MultiThreadedComments {
     let (leading, trailing) = comments.take_all();
     let leading = Rc::try_unwrap(leading).unwrap().into_inner();
     let trailing = Rc::try_unwrap(trailing).unwrap().into_inner();
-    MultiThreadedComments {
+    Self::from_leading_and_trailing(leading, trailing)
+  }
+
+  pub fn from_leading_and_trailing(
+    leading: SingleThreadedCommentsMapInner,
+    trailing: SingleThreadedCommentsMapInner,
+  ) -> Self {
+    Self {
       inner: Arc::new(MultiThreadedCommentsInner { leading, trailing }),
     }
   }

--- a/src/comments.rs
+++ b/src/comments.rs
@@ -59,6 +59,19 @@ impl MultiThreadedComments {
     SingleThreadedComments::from_leading_and_trailing(leading, trailing)
   }
 
+  pub fn into_single_threaded(self) -> SingleThreadedComments {
+    let inner = match Arc::try_unwrap(self.inner) {
+      Ok(inner) => inner,
+      Err(inner) => MultiThreadedCommentsInner {
+        leading: inner.leading.clone(),
+        trailing: inner.trailing.clone(),
+      },
+    };
+    let leading = Rc::new(RefCell::new(inner.leading));
+    let trailing = Rc::new(RefCell::new(inner.trailing));
+    SingleThreadedComments::from_leading_and_trailing(leading, trailing)
+  }
+
   /// Gets a reference to the leading comment map.
   pub fn leading_map(&self) -> &SingleThreadedCommentsMapInner {
     &self.inner.leading

--- a/src/comments.rs
+++ b/src/comments.rs
@@ -91,6 +91,9 @@ impl MultiThreadedComments {
     self.inner.trailing.get(&pos.as_byte_pos())
   }
 
+  /// Gets the comments as an `SwcComments` trait.
+  ///
+  /// Calling this is fast because it uses a shared reference.
   pub fn as_swc_comments(&self) -> Box<dyn SwcComments> {
     Box::new(SwcMultiThreadedComments(self.clone()))
   }

--- a/src/dep.rs
+++ b/src/dep.rs
@@ -24,9 +24,9 @@ impl ParsedSource {
   pub fn analyze_dependencies(&self) -> Vec<DependencyDescriptor> {
     match self.program_ref() {
       ast::Program::Module(module) => {
-        analyze_module_dependencies(&module, &self.comments().as_swc_comments())
+        analyze_module_dependencies(module, &self.comments().as_swc_comments())
       }
-      ast::Program::Script(_) => return vec![],
+      ast::Program::Script(_) => vec![],
     }
   }
 }

--- a/src/dep.rs
+++ b/src/dep.rs
@@ -24,7 +24,7 @@ impl ParsedSource {
   pub fn analyze_dependencies(&self) -> Vec<DependencyDescriptor> {
     match self.program_ref() {
       ast::Program::Module(module) => {
-        analyze_module_dependencies(module, &self.comments())
+        analyze_module_dependencies(module, self.comments())
       }
       ast::Program::Script(_) => vec![],
     }

--- a/src/parsed_source.rs
+++ b/src/parsed_source.rs
@@ -117,13 +117,8 @@ impl ParsedSource {
 
   /// Get the source's leading comments, where triple slash directives might
   /// be located.
-  pub fn get_leading_comments(&self) -> Vec<Comment> {
-    self
-      .inner
-      .comments
-      .get_leading(self.inner.program.range().start)
-      .cloned()
-      .unwrap_or_default()
+  pub fn get_leading_comments(&self) -> Option<&Vec<Comment>> {
+    self.inner.comments.get_leading(self.inner.program.start())
   }
 
   /// Gets the tokens found in the source file.

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -299,8 +299,8 @@ mod test {
       program.script().body[0],
       crate::swc::ast::Stmt::Expr(..)
     ));
-    assert_eq!(program.get_leading_comments().len(), 1);
-    assert_eq!(program.get_leading_comments()[0].text, " 1");
+    assert_eq!(program.get_leading_comments().unwrap().len(), 1);
+    assert_eq!(program.get_leading_comments().unwrap()[0].text, " 1");
     assert_eq!(program.tokens().len(), 3);
     assert_eq!(program.comments().get_vec().len(), 2);
   }

--- a/src/transpiling/mod.rs
+++ b/src/transpiling/mod.rs
@@ -189,7 +189,8 @@ impl ParsedSource {
       Ok(specifier) => FileName::Url(specifier),
       Err(_) => FileName::Custom(self.specifier().to_string()),
     };
-    source_map.new_source_file(file_name, self.text_info().text().to_string());
+    source_map
+      .new_source_file(file_name, self.text_info().text_str().to_string());
     // needs to align with what's done internally in source map
     assert_eq!(1, self.text_info().range().start.as_byte_pos().0);
     // we need the comments to be mutable, so make it single threaded

--- a/src/transpiling/mod.rs
+++ b/src/transpiling/mod.rs
@@ -474,7 +474,7 @@ fn is_fatal_syntax_error(error_kind: &SyntaxError) -> bool {
   )
 }
 
-pub(crate) fn swc_codegen_config() -> crate::swc::codegen::Config {
+pub fn swc_codegen_config() -> crate::swc::codegen::Config {
   // NOTICE ON UPGRADE: This struct has #[non_exhaustive] on it,
   // which prevents creating a struct expr here. For that reason,
   // inspect the struct on swc upgrade and explicitly specify any


### PR DESCRIPTION
Need this in order to do module analysis from an swc module without a `ParsedSource`