### PR TITLE
feat: ability to add scope analysis to a `ParsedSource`

### DIFF
--- a/src/parsed_source.rs
+++ b/src/parsed_source.rs
@@ -4,6 +4,7 @@ use std::fmt;
 use std::sync::Arc;
 
 use crate::comments::MultiThreadedComments;
+use crate::scope_analysis_transform;
 use crate::swc::ast::Module;
 use crate::swc::ast::Program;
 use crate::swc::ast::Script;
@@ -15,6 +16,7 @@ use crate::MediaType;
 use crate::SourceRangedForSpanned;
 use crate::SourceTextInfo;
 
+#[derive(Clone)]
 pub(crate) struct SyntaxContexts {
   pub unresolved: SyntaxContext,
   pub top_level: SyntaxContext,
@@ -130,6 +132,48 @@ impl ParsedSource {
       .tokens
       .as_ref()
       .expect("Tokens not found because they were not captured during parsing.")
+  }
+
+  /// Adds scope analysis to the parsed source if not parsed
+  /// with scope analysis.
+  ///
+  /// Note: This will attempt to not clone the underlying data, but
+  /// will clone if multiple clones of the `ParsedSource` exist.
+  pub fn with_scope_analysis(self) -> Self {
+    if self.has_scope_analysis() {
+      self
+    } else {
+      let mut inner = match Arc::try_unwrap(self.inner) {
+        Ok(inner) => inner,
+        Err(arc_inner) => ParsedSourceInner {
+          // all of these are/should be cheap to clone
+          specifier: arc_inner.specifier.clone(),
+          media_type: arc_inner.media_type,
+          text_info: arc_inner.text_info.clone(),
+          comments: arc_inner.comments.clone(),
+          program: arc_inner.program.clone(),
+          tokens: arc_inner.tokens.clone(),
+          syntax_contexts: arc_inner.syntax_contexts.clone(),
+          diagnostics: arc_inner.diagnostics.clone(),
+        },
+      };
+      let program = match Arc::try_unwrap(inner.program) {
+        Ok(program) => program,
+        Err(program) => (*program).clone(),
+      };
+      let (program, context) = scope_analysis_transform(program);
+      inner.program = Arc::new(program);
+      inner.syntax_contexts = context;
+      ParsedSource {
+        inner: Arc::new(inner),
+      }
+    }
+  }
+
+  /// Gets if the source's program has scope information stored
+  /// in the identifiers.
+  pub fn has_scope_analysis(&self) -> bool {
+    self.inner.syntax_contexts.is_some()
   }
 
   /// Gets the top level context used when parsing with scope analysis.

--- a/src/parsed_source.rs
+++ b/src/parsed_source.rs
@@ -139,7 +139,7 @@ impl ParsedSource {
   ///
   /// Note: This will attempt to not clone the underlying data, but
   /// will clone if multiple clones of the `ParsedSource` exist.
-  pub fn with_scope_analysis(self) -> Self {
+  pub fn into_with_scope_analysis(self) -> Self {
     if self.has_scope_analysis() {
       self
     } else {

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -138,35 +138,7 @@ fn parse(
   let program = post_process(program);
 
   let (program, syntax_contexts) = if params.scope_analysis {
-    #[cfg(feature = "transforms")]
-    {
-      use crate::swc::common::Globals;
-      use crate::swc::common::Mark;
-      use crate::swc::common::SyntaxContext;
-      use crate::swc::transforms::resolver;
-      use crate::swc::visit::FoldWith;
-
-      let globals = Globals::new();
-      crate::swc::common::GLOBALS.set(&globals, || {
-        let unresolved_mark = Mark::new();
-        let top_level_mark = Mark::new();
-        let program = program.fold_with(&mut resolver(
-          unresolved_mark,
-          top_level_mark,
-          true,
-        ));
-
-        (
-          program,
-          Some(crate::SyntaxContexts {
-            unresolved: SyntaxContext::empty().apply_mark(unresolved_mark),
-            top_level: SyntaxContext::empty().apply_mark(top_level_mark),
-          }),
-        )
-      })
-    }
-    #[cfg(not(feature = "transforms"))]
-    panic!("Cannot parse with scope analysis. Please enable the 'transforms' feature.")
+    scope_analysis_transform(program)
   } else {
     (program, None)
   };
@@ -181,6 +153,46 @@ fn parse(
     syntax_contexts,
     diagnostics,
   ))
+}
+
+pub(crate) fn scope_analysis_transform(
+  program: Program,
+) -> (Program, Option<crate::SyntaxContexts>) {
+  #[cfg(feature = "transforms")]
+  {
+    scope_analysis_transform_inner(program)
+  }
+  #[cfg(not(feature = "transforms"))]
+  panic!(
+    "Cannot parse with scope analysis. Please enable the 'transforms' feature."
+  )
+}
+
+#[cfg(feature = "transforms")]
+fn scope_analysis_transform_inner(
+  program: Program,
+) -> (Program, Option<crate::SyntaxContexts>) {
+  use crate::swc::common::Globals;
+  use crate::swc::common::Mark;
+  use crate::swc::common::SyntaxContext;
+  use crate::swc::transforms::resolver;
+  use crate::swc::visit::FoldWith;
+
+  let globals = Globals::new();
+  crate::swc::common::GLOBALS.set(&globals, || {
+    let unresolved_mark = Mark::new();
+    let top_level_mark = Mark::new();
+    let program =
+      program.fold_with(&mut resolver(unresolved_mark, top_level_mark, true));
+
+    (
+      program,
+      Some(crate::SyntaxContexts {
+        unresolved: SyntaxContext::empty().apply_mark(unresolved_mark),
+        top_level: SyntaxContext::empty().apply_mark(top_level_mark),
+      }),
+    )
+  })
 }
 
 #[allow(clippy::type_complexity)]
@@ -452,6 +464,53 @@ mod test {
       // these should be the same identifier
       assert_eq!(func_decl.ident.to_id(), call_expr_id.to_id());
       // but these shouldn't be
+      assert_ne!(func_decl.ident.to_id(), func_decl_inner_expr.to_id());
+    });
+  }
+
+  #[cfg(all(feature = "view", feature = "transforms"))]
+  #[test]
+  fn should_allow_scope_analysis_after_the_fact() {
+    let parsed_source = parse_module(ParseParams {
+      specifier: "my_file.js".to_string(),
+      text_info: SourceTextInfo::from_string(
+        "export function test() { const test = 2; test; } test()".to_string(),
+      ),
+      media_type: MediaType::JavaScript,
+      capture_tokens: true,
+      maybe_syntax: None,
+      scope_analysis: false,
+    })
+    .unwrap();
+
+    parsed_source.with_view(|view| {
+      use crate::view::*;
+      let func_decl = view.children()[0]
+        .expect::<ExportDecl>()
+        .decl
+        .expect::<FnDecl>();
+      let func_decl_inner_expr = func_decl.function.body.unwrap().stmts[1]
+        .expect::<ExprStmt>()
+        .expr
+        .expect::<Ident>();
+      // these will be equal because scope analysis hasn't been done
+      assert_eq!(func_decl.ident.to_id(), func_decl_inner_expr.to_id());
+    });
+
+    // now do scope analysis
+    let parsed_source = parsed_source.into_with_scope_analysis();
+
+    parsed_source.with_view(|view| {
+      use crate::view::*;
+      let func_decl = view.children()[0]
+        .expect::<ExportDecl>()
+        .decl
+        .expect::<FnDecl>();
+      let func_decl_inner_expr = func_decl.function.body.unwrap().stmts[1]
+        .expect::<ExprStmt>()
+        .expr
+        .expect::<Ident>();
+      // now they'll be not equal because scope analysis has occurred
       assert_ne!(func_decl.ident.to_id(), func_decl_inner_expr.to_id());
     });
   }

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -156,11 +156,11 @@ fn parse(
 }
 
 pub(crate) fn scope_analysis_transform(
-  program: Program,
+  _program: Program,
 ) -> (Program, Option<crate::SyntaxContexts>) {
   #[cfg(feature = "transforms")]
   {
-    scope_analysis_transform_inner(program)
+    scope_analysis_transform_inner(_program)
   }
   #[cfg(not(feature = "transforms"))]
   panic!(


### PR DESCRIPTION
With fast remote type checking I need the ability to do scope analysis for only certain specifiers. This started getting really complicated and I think it's easier to just do this on demand. The catch is that there can only be one reference to the underlying data in the `ParsedSource` or else a whole clone happens, but this is generally how things work for us anyway.