### PR TITLE
refactor(diagnostics): use `Cow<str>` instead of `impl Display`

### DIFF
--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -216,10 +216,10 @@ pub trait Diagnostic {
   fn level(&self) -> DiagnosticLevel;
 
   /// The diagnostic code, like `no-explicit-any` or `ban-untagged-ignore`.
-  fn code(&self) -> impl fmt::Display + '_;
+  fn code(&self) -> Cow<str>;
 
   /// The human-readable diagnostic message.
-  fn message(&self) -> impl fmt::Display + '_;
+  fn message(&self) -> Cow<str>;
 
   /// The location this diagnostic is associated with.
   fn location(&self) -> DiagnosticLocation;
@@ -228,7 +228,7 @@ pub trait Diagnostic {
   fn snippet(&self) -> Option<DiagnosticSnippet<'_>>;
 
   /// A hint for fixing the diagnostic.
-  fn hint(&self) -> Option<impl fmt::Display + '_>;
+  fn hint(&self) -> Option<Cow<str>>;
 
   /// A snippet showing how the diagnostic can be fixed.
   fn snippet_fixed(&self) -> Option<DiagnosticSnippet<'_>>;

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -216,10 +216,10 @@ pub trait Diagnostic {
   fn level(&self) -> DiagnosticLevel;
 
   /// The diagnostic code, like `no-explicit-any` or `ban-untagged-ignore`.
-  fn code(&self) -> Cow<str>;
+  fn code(&self) -> Cow<'_, str>;
 
   /// The human-readable diagnostic message.
-  fn message(&self) -> Cow<str>;
+  fn message(&self) -> Cow<'_, str>;
 
   /// The location this diagnostic is associated with.
   fn location(&self) -> DiagnosticLocation;
@@ -228,7 +228,7 @@ pub trait Diagnostic {
   fn snippet(&self) -> Option<DiagnosticSnippet<'_>>;
 
   /// A hint for fixing the diagnostic.
-  fn hint(&self) -> Option<Cow<str>>;
+  fn hint(&self) -> Option<Cow<'_, str>>;
 
   /// A snippet showing how the diagnostic can be fixed.
   fn snippet_fixed(&self) -> Option<DiagnosticSnippet<'_>>;
@@ -236,7 +236,7 @@ pub trait Diagnostic {
   fn info(&self) -> Cow<'_, [Cow<'_, str>]>;
 
   /// An optional URL to the documentation for the diagnostic.
-  fn docs_url(&self) -> Option<impl fmt::Display + '_>;
+  fn docs_url(&self) -> Option<Cow<'_, str>>;
 
   fn display(&self) -> DiagnosticDisplay<Self> {
     DiagnosticDisplay { diagnostic: self }

--- a/src/types.rs
+++ b/src/types.rs
@@ -53,8 +53,8 @@ impl Diagnostic for ParseDiagnostic {
     DiagnosticLevel::Error
   }
 
-  fn code(&self) -> impl fmt::Display + '_ {
-    match &self.kind {
+  fn code(&self) -> Cow<'_, str> {
+    Cow::Borrowed(match &self.kind {
       SyntaxError::Eof => "eof",
       SyntaxError::DeclNotAllowed => "decl-not-allowed",
       SyntaxError::UsingDeclNotAllowed => "using-decl-not-allowed",
@@ -272,10 +272,10 @@ impl Diagnostic for ParseDiagnostic {
       SyntaxError::ReservedTypeAssertion => "reserved-type-assertion",
       SyntaxError::ReservedArrowTypeParam => "reserved-arrow-type-param",
       _ => "unknown",
-    }
+    })
   }
 
-  fn message(&self) -> impl fmt::Display + '_ {
+  fn message(&self) -> Cow<'_, str> {
     self.kind.msg()
   }
 
@@ -301,8 +301,8 @@ impl Diagnostic for ParseDiagnostic {
     })
   }
 
-  fn hint(&self) -> Option<impl fmt::Display + '_> {
-    None::<&str>
+  fn hint(&self) -> Option<Cow<'_, str>> {
+    None
   }
 
   fn snippet_fixed(&self) -> Option<crate::diagnostics::DiagnosticSnippet<'_>> {
@@ -313,8 +313,8 @@ impl Diagnostic for ParseDiagnostic {
     Cow::Borrowed(&[])
   }
 
-  fn docs_url(&self) -> Option<impl fmt::Display + '_> {
-    None::<&str>
+  fn docs_url(&self) -> Option<Cow<'_, str>> {
+    None
   }
 }
 


### PR DESCRIPTION
This works better with Cow for when a diagnostic contains a diagnostic that returns these methods from the inner diagnostic. With `impl Display` you need to convert everything into a known concrete type on the outer diagnostic (ex. call to_string() on everything).