### PR TITLE
fix: use swc `Comment` trait for emitting

### DIFF
--- a/src/emit.rs
+++ b/src/emit.rs
@@ -2,7 +2,6 @@
 
 use anyhow::Result;
 use base64::Engine;
-use swc_common::comments::SingleThreadedComments;
 
 use crate::swc::ast::Program;
 use crate::swc::codegen::text_writer::JsWriter;
@@ -54,7 +53,7 @@ pub struct EmittedSource {
 /// comments, and optionally also a source map.
 pub fn emit(
   program: &Program,
-  comments: &SingleThreadedComments,
+  comments: &dyn crate::swc::common::comments::Comments,
   source_map: &SourceMap,
   emit_options: &EmitOptions,
 ) -> Result<EmittedSource> {


### PR DESCRIPTION
For making the graph `Send` again: https://github.com/denoland/deno_graph/commit/2b1b063cb5b9bce852badf31283439b56154d64d#r140885097