### PR TITLE
feat: skip serialize option for jsx precompile

### DIFF
--- a/src/transpiling/jsx_precompile.rs
+++ b/src/transpiling/jsx_precompile.rs
@@ -497,7 +497,7 @@ fn merge_serializable_children(
           buf = String::new()
         }
 
-        if is_serializable(&jsx_el.opening, &skip_serialize) {
+        if is_serializable(&jsx_el.opening, skip_serialize) {
           serializable_count += 1;
         }
 

--- a/src/transpiling/mod.rs
+++ b/src/transpiling/mod.rs
@@ -84,6 +84,8 @@ pub struct TranspileOptions {
   /// with dynamic content. Defaults to `false`, mutually exclusive with
   /// `transform_jsx`.
   pub precompile_jsx: bool,
+  /// Only enabled when
+  pub precompile_jsx_skip_elements: Option<Vec<String>>,
   /// Should import declarations be transformed to variable declarations using
   /// a dynamic import. This is useful for import & export declaration support
   /// in script contexts such as the Deno REPL.  Defaults to `false`.
@@ -104,6 +106,7 @@ impl Default for TranspileOptions {
       jsx_import_source: None,
       transform_jsx: true,
       precompile_jsx: false,
+      precompile_jsx_skip_elements: None,
       var_decl_imports: false,
     }
   }
@@ -258,6 +261,7 @@ pub fn fold_program(
     Optional::new(
       as_folder(jsx_precompile::JsxPrecompile::new(
         options.jsx_import_source.clone().unwrap_or_default(),
+        options.precompile_jsx_skip_elements.clone(),
       )),
       options.jsx_import_source.is_some()
         && !options.transform_jsx
@@ -1255,6 +1259,7 @@ for (let i = 0; i < testVariable >> 1; i++) callCount++;
     let transpile_options = TranspileOptions {
       transform_jsx: false,
       precompile_jsx: true,
+      precompile_jsx_skip_elements: Some(vec!["p".to_string()]),
       jsx_import_source: Some("react".to_string()),
       ..Default::default()
     };
@@ -1263,19 +1268,18 @@ for (let i = 0; i < testVariable >> 1; i++) callCount++;
       .unwrap()
       .text;
     let expected1 = r#"import { jsx as _jsx, jsxTemplate as _jsxTemplate } from "react/jsx-runtime";
-const $$_tpl_2 = [
-  "<p>asdf</p>"
-];
 const $$_tpl_1 = [
   "<span>hello</span>foo",
   ""
 ];
 const a = _jsx(Foo, {
   children: _jsxTemplate($$_tpl_1, _jsx(Bar, {
-    children: _jsxTemplate($$_tpl_2)
+    children: _jsx("p", {
+      children: "asdf"
+    })
   }))
 });
-//# sourceMappingURL=data:application/json;base64,eyJ2ZXJza"#;
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2Vz"#;
     assert_eq!(&code[0..expected1.len()], expected1);
   }
 

--- a/src/transpiling/mod.rs
+++ b/src/transpiling/mod.rs
@@ -84,7 +84,8 @@ pub struct TranspileOptions {
   /// with dynamic content. Defaults to `false`, mutually exclusive with
   /// `transform_jsx`.
   pub precompile_jsx: bool,
-  /// Only enabled when
+  /// List of elements that should not be precompiled when the JSX precompile
+  /// transform is used.
   pub precompile_jsx_skip_elements: Option<Vec<String>>,
   /// Should import declarations be transformed to variable declarations using
   /// a dynamic import. This is useful for import & export declaration support


### PR DESCRIPTION
In Fresh we do add some properties automatically to certain elements under the hood, like marking a link as "active" when it matches the current route among other things. For that we need to materialize the full `vnode` to know what kind of element were dealing with and what kind of other props it has.

To address this, this PR adds a new option to the transform which allows the user to pass an array of element names like `["a", "img"]` which should be excluded from being be precompiled by the transform. Plan is to add a new option in `deno.json#compilerOptions` for this.