### PR TITLE
fix(BREAKING): flip `keep_comments` to `remove_comments`

### DIFF
--- a/src/emit.rs
+++ b/src/emit.rs
@@ -27,8 +27,8 @@ pub struct EmitOptions {
   pub source_map: SourceMapOption,
   /// Whether to inline the source contents in the source map. Defaults to `true`.
   pub inline_sources: bool,
-  /// Whether to keep comments in the output. Defaults to `false`.
-  pub keep_comments: bool,
+  /// Whether to remove comments in the output. Defaults to `false`.
+  pub remove_comments: bool,
 }
 
 impl Default for EmitOptions {
@@ -36,7 +36,7 @@ impl Default for EmitOptions {
     EmitOptions {
       source_map: SourceMapOption::default(),
       inline_sources: true,
-      keep_comments: false,
+      remove_comments: false,
     }
   }
 }
@@ -82,10 +82,10 @@ pub fn emit(
 
     let mut emitter = crate::swc::codegen::Emitter {
       cfg: swc_codegen_config(),
-      comments: if emit_options.keep_comments {
-        Some(&comments)
-      } else {
+      comments: if emit_options.remove_comments {
         None
+      } else {
+        Some(&comments)
       },
       cm: source_map.clone(),
       wr: writer,

--- a/src/transpiling/mod.rs
+++ b/src/transpiling/mod.rs
@@ -832,7 +832,13 @@ function App() {
     })
     .unwrap();
     let code = module
-      .transpile(&TranspileOptions::default(), &EmitOptions::default())
+      .transpile(
+        &TranspileOptions::default(),
+        &EmitOptions {
+          remove_comments: true,
+          ..Default::default()
+        },
+      )
       .unwrap()
       .into_source()
       .text;
@@ -868,7 +874,7 @@ function App() {
       .transpile(
         &TranspileOptions::default(),
         &EmitOptions {
-          keep_comments: true,
+          remove_comments: false,
           ..Default::default()
         },
       )
@@ -909,7 +915,13 @@ function App() {
       ..Default::default()
     };
     let code = module
-      .transpile(&transpile_options, &EmitOptions::default())
+      .transpile(
+        &transpile_options,
+        &EmitOptions {
+          remove_comments: true,
+          ..Default::default()
+        },
+      )
       .unwrap()
       .into_source()
       .text;
@@ -948,7 +960,13 @@ function App() {
       ..Default::default()
     };
     let code = module
-      .transpile(&transpile_options, &EmitOptions::default())
+      .transpile(
+        &transpile_options,
+        &EmitOptions {
+          remove_comments: true,
+          ..Default::default()
+        },
+      )
       .unwrap()
       .into_source()
       .text;
@@ -997,11 +1015,11 @@ function App() {
       .unwrap()
       .into_source()
       .text;
-    let expected = r#"const { "jsx": _jsx, "Fragment": _Fragment } = await import("jsx_lib/jsx-runtime");
+    let expected = r#"/** @jsxImportSource jsx_lib */ const { "jsx": _jsx, "Fragment": _Fragment } = await import("jsx_lib/jsx-runtime");
 const example = await import("example");
 function App() {
-  return _jsx("div", {
-    children: _jsx(_Fragment, {})
+  return /*#__PURE__*/ _jsx("div", {
+    children: /*#__PURE__*/ _jsx(_Fragment, {})
   });
 "#;
     assert_eq!(&code[..expected.len()], expected);


### PR DESCRIPTION
People check for comments in `.toString()` so we need to keep the comments by default.