### PR TITLE
Support concurrent `swc_common` via feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1036,6 +1036,7 @@ dependencies = [
  "new_debug_unreachable",
  "num-bigint",
  "once_cell",
+ "parking_lot",
  "rustc-hash",
  "serde",
  "siphasher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ typescript = ["transforms", "swc_ecma_transforms_typescript"]
 utils = ["swc_ecma_utils"]
 view = ["dprint-swc-ext/view"]
 visit = ["swc_ecma_visit", "swc_visit", "swc_visit_macros", "swc_macros_common"]
+concurrent = ["swc_common/concurrent"]
 
 [dependencies]
 anyhow = { version = "1.0.64", optional = true }

--- a/src/source_map.rs
+++ b/src/source_map.rs
@@ -1,14 +1,13 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-use std::rc::Rc;
-
+use crate::swc::common::sync::Lrc;
 use crate::swc::common::SourceFile;
 
 use crate::ModuleSpecifier;
 
 #[derive(Clone, Default)]
 pub struct SourceMap {
-  inner: Rc<crate::swc::common::SourceMap>,
+  inner: Lrc<crate::swc::common::SourceMap>,
 }
 
 impl SourceMap {
@@ -16,11 +15,11 @@ impl SourceMap {
     let map = Self::default();
     map
       .inner
-      .new_source_file(Rc::new(swc_common::FileName::Url(specifier)), source);
+      .new_source_file(Lrc::new(swc_common::FileName::Url(specifier)), source);
     map
   }
 
-  pub fn inner(&self) -> &Rc<crate::swc::common::SourceMap> {
+  pub fn inner(&self) -> &Lrc<crate::swc::common::SourceMap> {
     &self.inner
   }
 
@@ -28,9 +27,9 @@ impl SourceMap {
     &self,
     specifier: ModuleSpecifier,
     source: String,
-  ) -> Rc<SourceFile> {
+  ) -> Lrc<SourceFile> {
     self
       .inner
-      .new_source_file(Rc::new(swc_common::FileName::Url(specifier)), source)
+      .new_source_file(Lrc::new(swc_common::FileName::Url(specifier)), source)
   }
 }

--- a/src/transpiling/mod.rs
+++ b/src/transpiling/mod.rs
@@ -1,7 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 use std::borrow::Cow;
-use std::rc::Rc;
 use std::sync::Arc;
 
 use anyhow::Result;
@@ -14,6 +13,7 @@ use crate::swc::ast::Program;
 use crate::swc::common::chain;
 use crate::swc::common::comments::SingleThreadedComments;
 use crate::swc::common::errors::Diagnostic as SwcDiagnostic;
+use crate::swc::common::sync::{Lrc, Send, Sync};
 use crate::swc::parser::error::SyntaxError;
 use crate::swc::transforms::fixer;
 use crate::swc::transforms::helpers;
@@ -349,8 +349,11 @@ fn transpile(
 
 #[derive(Default, Clone)]
 struct DiagnosticCollector {
-  diagnostics_cell: Rc<RefCell<Vec<SwcDiagnostic>>>,
+  diagnostics_cell: Lrc<RefCell<Vec<SwcDiagnostic>>>,
 }
+
+unsafe impl Send for DiagnosticCollector {}
+unsafe impl Sync for DiagnosticCollector {}
 
 impl DiagnosticCollector {
   pub fn into_handler(self) -> crate::swc::common::errors::Handler {

--- a/src/transpiling/transforms.rs
+++ b/src/transpiling/transforms.rs
@@ -288,6 +288,7 @@ mod test {
   use crate::swc::ast::Module;
   use crate::swc::codegen::text_writer::JsWriter;
   use crate::swc::codegen::Node;
+  use crate::swc::common::sync::Lrc;
   use crate::swc::common::FileName;
   use crate::swc::common::SourceMap;
   use crate::swc::parser::Parser;
@@ -298,7 +299,6 @@ mod test {
   use crate::swc::visit::FoldWith;
   use crate::ModuleSpecifier;
   use pretty_assertions::assert_eq;
-  use std::rc::Rc;
 
   use super::*;
 
@@ -498,10 +498,10 @@ mod test {
     assert_eq!(output, format!("{}\n", expected_output));
   }
 
-  fn parse(src: &str) -> (Rc<SourceMap>, Module) {
-    let source_map = Rc::new(SourceMap::default());
+  fn parse(src: &str) -> (Lrc<SourceMap>, Module) {
+    let source_map = Lrc::new(SourceMap::default());
     let source_file = source_map.new_source_file(
-      Rc::new(FileName::Url(
+      Lrc::new(FileName::Url(
         ModuleSpecifier::parse("file:///test.ts").unwrap(),
       )),
       src.to_string(),
@@ -514,7 +514,7 @@ mod test {
     (source_map, parser.parse_module().unwrap())
   }
 
-  fn print(source_map: Rc<SourceMap>, module: Module) -> String {
+  fn print(source_map: Lrc<SourceMap>, module: Module) -> String {
     let mut buf = vec![];
     {
       let mut writer =


### PR DESCRIPTION
When using `swc_common` with `feature = ["concurrent"]`, `deno_ast` fails to compile.

```
error[E0277]: `Rc<RefCell<Vec<swc_common::errors::Diagnostic>>>` cannot be sent between threads safely
   --> .../deno_ast-0.38.2/src/transpiling/mod.rs:324:46
    |
324 | impl crate::swc::common::errors::Emitter for DiagnosticCollector {
    |                                              ^^^^^^^^^^^^^^^^^^^ 
    |    `Rc<RefCell<Vec<swc_common::errors::Diagnostic>>>` cannot be sent between threads safely
    |
    = help: within `DiagnosticCollector`, the trait `Send` is not implemented for 
      `Rc<RefCell<Vec<swc_common::errors::Diagnostic>>>`, which is required by `DiagnosticCollector: Send`

error[E0308]: mismatched types
  --> .../deno_ast-0.38.2/src/emit.rs:79:7
   |
78 |     let mut writer = Box::new(JsWriter::new(
   |                               ------------- arguments to this function are incorrect
79 |       source_map.clone(),
   |       ^^^^^^^^^^^^^^^^^^ expected `Arc<SourceMap>`, found `Rc<SourceMap>`
   |
   = note: expected struct `Arc<swc_common::SourceMap>`
              found struct `Rc<swc_common::SourceMap>`
```

Resolves #219 

cc @dsherret