### PR TITLE
perf: turn off jsx transforms for non-jsx compatible files

### DIFF
--- a/src/transpiling/mod.rs
+++ b/src/transpiling/mod.rs
@@ -281,12 +281,11 @@ fn resolve_transpile_options(
 ) -> Cow<TranspileOptions> {
   if options.transform_jsx {
     let allows_jsx = match media_type {
+      MediaType::Jsx | MediaType::Tsx => true,
       MediaType::JavaScript
       | MediaType::Mjs
       | MediaType::Cjs
-      | MediaType::Jsx
-      | MediaType::Tsx => true,
-      MediaType::Mts
+      | MediaType::Mts
       | MediaType::Cts
       | MediaType::Dts
       | MediaType::Dmts

--- a/src/transpiling/mod.rs
+++ b/src/transpiling/mod.rs
@@ -275,10 +275,10 @@ impl ParsedSource {
   }
 }
 
-fn resolve_transpile_options<'a>(
+fn resolve_transpile_options(
   media_type: MediaType,
-  options: &'a TranspileOptions,
-) -> Cow<'a, TranspileOptions> {
+  options: &TranspileOptions,
+) -> Cow<TranspileOptions> {
   if options.transform_jsx {
     let allows_jsx = match media_type {
       MediaType::JavaScript


### PR DESCRIPTION
```
> hyperfine --warmup=3 ".\baseline.exe" ".\new.exe"
Benchmark 1: .\baseline.exe
  Time (mean ± σ):     188.0 ms ±   6.6 ms    [User: 58.0 ms, System: 6.6 ms]
  Range (min … max):   181.4 ms … 204.9 ms    14 runs

Benchmark 2: .\new.exe
  Time (mean ± σ):     181.0 ms ±   4.8 ms    [User: 72.3 ms, System: 8.6 ms]
  Range (min … max):   171.9 ms … 193.0 ms    16 runs

Summary
  .\new.exe ran
    1.04 ± 0.05 times faster than .\baseline.exe
```