### PR TITLE
perf(emit): allow deferring or excluding utf8 conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode/
+.vs/
 /target

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -144,10 +144,9 @@ pub fn emit(
       let inline_buf = &inline_buf[..size];
       let prelude_text = "//# sourceMappingURL=data:application/json;base64,";
       let src_has_trailing_newline = src_buf.ends_with(&[b'\n']);
-      let additional_capacity =
-        src_has_trailing_newline.then_some(0).unwrap_or(1)
-          + prelude_text.len()
-          + inline_buf.len();
+      let additional_capacity = if src_has_trailing_newline { 0 } else { 1 }
+        + prelude_text.len()
+        + inline_buf.len();
       let expected_final_capacity = src_buf.len() + additional_capacity;
       src_buf.reserve(additional_capacity);
       if !src_has_trailing_newline {

--- a/src/transpiling/jsx_precompile.rs
+++ b/src/transpiling/jsx_precompile.rs
@@ -2692,6 +2692,8 @@ const a = _jsxTemplate($$_tpl_1, _jsx("img", {
       },
     )
     .unwrap()
+    .into_string()
+    .unwrap()
     .text
   }
 }


### PR DESCRIPTION
We can avoid converting to utf-8 and instead just pass the module source as bytes to v8.