### PR TITLE
perf: lazily create `SourceTextInfo`

### DIFF
--- a/src/cjs_parse.rs
+++ b/src/cjs_parse.rs
@@ -618,7 +618,7 @@ mod test {
   fn parse_cjs(source: &str) -> CjsAnalysisTester {
     let parsed_source = parse_script(ParseParams {
       specifier: ModuleSpecifier::parse("file:///example.js").unwrap(),
-      text_info: SourceTextInfo::from_string(source.to_string()),
+      text: source.into(),
       media_type: MediaType::Cjs,
       capture_tokens: true,
       scope_analysis: false,

--- a/src/cjs_parse.rs
+++ b/src/cjs_parse.rs
@@ -572,7 +572,6 @@ mod test {
   use crate::MediaType;
   use crate::ModuleSpecifier;
   use crate::ParseParams;
-  use crate::SourceTextInfo;
 
   use super::*;
 

--- a/src/comments.rs
+++ b/src/comments.rs
@@ -202,7 +202,6 @@ mod test {
   use crate::ModuleSpecifier;
   use crate::MultiThreadedComments;
   use crate::ParseParams;
-  use crate::SourceTextInfo;
   use crate::StartSourcePos;
 
   #[test]
@@ -255,16 +254,13 @@ mod test {
   ) -> (SingleThreadedComments, StartSourcePos) {
     let module = parse_module(ParseParams {
       specifier: ModuleSpecifier::parse("file:///file.ts").unwrap(),
-      text_info: SourceTextInfo::from_string(text.to_string()),
+      text: text.into(),
       media_type: MediaType::TypeScript,
       capture_tokens: false,
       maybe_syntax: None,
       scope_analysis: false,
     })
     .expect("expects a module");
-    (
-      module.comments().as_single_threaded(),
-      module.text_info().range().start,
-    )
+    (module.comments().as_single_threaded(), module.range().start)
   }
 }

--- a/src/dep.rs
+++ b/src/dep.rs
@@ -529,7 +529,7 @@ mod tests {
   ) -> (SourcePos, Vec<DependencyDescriptor>) {
     let source = crate::parse_module(crate::ParseParams {
       specifier: ModuleSpecifier::parse(specifier).unwrap(),
-      text_info: crate::SourceTextInfo::from_string(source.to_string()),
+      text: source.into(),
       media_type: crate::MediaType::Tsx,
       capture_tokens: false,
       scope_analysis: false,

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -2,6 +2,9 @@
 
 use std::sync::Arc;
 
+use dprint_swc_ext::common::SourceTextInfo;
+use dprint_swc_ext::common::StartSourcePos;
+
 use crate::comments::MultiThreadedComments;
 use crate::swc::ast::EsVersion;
 use crate::swc::ast::Module;
@@ -20,7 +23,6 @@ use crate::MediaType;
 use crate::ModuleSpecifier;
 use crate::ParseDiagnostic;
 use crate::ParsedSource;
-use crate::SourceTextInfo;
 
 /// Ecmascript version used for lexing and parsing.
 pub const ES_VERSION: EsVersion = EsVersion::Es2021;
@@ -29,8 +31,8 @@ pub const ES_VERSION: EsVersion = EsVersion::Es2021;
 pub struct ParseParams {
   /// Specifier of the source text.
   pub specifier: ModuleSpecifier,
-  /// Source text stored in a `SourceTextInfo`.
-  pub text_info: SourceTextInfo,
+  /// Source text.
+  pub text: Arc<str>,
   /// Media type of the source text.
   pub media_type: MediaType,
   /// Whether to capture tokens or not.
@@ -62,7 +64,7 @@ pub fn parse_program(
 ///  deno_ast::ParseParams {
 ///    specifier: deno_ast::ModuleSpecifier::parse("file:///my_file.ts").unwrap(),
 ///    media_type: deno_ast::MediaType::TypeScript,
-///    text_info: deno_ast::SourceTextInfo::from_string("".to_string()),
+///    text: "console.log(4);".into(),
 ///    capture_tokens: true,
 ///    maybe_syntax: None,
 ///    scope_analysis: false,
@@ -135,9 +137,13 @@ fn parse(
   parse_mode: ParseMode,
   post_process: impl FnOnce(Program, &Globals) -> Program,
 ) -> Result<ParsedSource, ParseDiagnostic> {
-  let source = params.text_info;
+  let source = params.text;
   let specifier = params.specifier;
-  let input = source.as_string_input();
+  let input = StringInput::new(
+    source.as_ref(),
+    StartSourcePos::START_SOURCE_POS.as_byte_pos(),
+    (StartSourcePos::START_SOURCE_POS + source.len()).as_byte_pos(),
+  );
   let media_type = params.media_type;
   let syntax = params
     .maybe_syntax
@@ -145,12 +151,25 @@ fn parse(
   let (comments, program, tokens, errors) =
     parse_string_input(input, syntax, params.capture_tokens, parse_mode)
       .map_err(|err| {
-        ParseDiagnostic::from_swc_error(err, &specifier, source.clone())
+        let source_text_info = SourceTextInfo::new(source.clone());
+        ParseDiagnostic::from_swc_error(err, &specifier, source_text_info)
       })?;
-  let diagnostics = errors
-    .into_iter()
-    .map(|err| ParseDiagnostic::from_swc_error(err, &specifier, source.clone()))
-    .collect();
+  let diagnostics = if errors.is_empty() {
+    Vec::new()
+  } else {
+    // todo(dsherret): remove usages of SourceTextInfo in diagnostics
+    let source_text_info = SourceTextInfo::new(source.clone());
+    errors
+      .into_iter()
+      .map(|err| {
+        ParseDiagnostic::from_swc_error(
+          err,
+          &specifier,
+          source_text_info.clone(),
+        )
+      })
+      .collect()
+  };
   let globals = Globals::default();
   let program = post_process(program, &globals);
 
@@ -313,7 +332,7 @@ mod test {
   fn should_parse_program() {
     let program = parse_program(ParseParams {
       specifier: ModuleSpecifier::parse("file:///my_file.js").unwrap(),
-      text_info: SourceTextInfo::from_string("// 1\n1 + 1\n// 2".to_string()),
+      text: "// 1\n1 + 1\n// 2".into(),
       media_type: MediaType::JavaScript,
       capture_tokens: true,
       maybe_syntax: None,
@@ -321,7 +340,7 @@ mod test {
     })
     .unwrap();
     assert_eq!(program.specifier().as_str(), "file:///my_file.js");
-    assert_eq!(program.text_info().text_str(), "// 1\n1 + 1\n// 2");
+    assert_eq!(program.text().as_ref(), "// 1\n1 + 1\n// 2");
     assert_eq!(program.media_type(), MediaType::JavaScript);
     assert!(matches!(
       program.script().body[0],
@@ -337,7 +356,7 @@ mod test {
   fn should_parse_module() {
     let program = parse_module(ParseParams {
       specifier: ModuleSpecifier::parse("file:///my_file.js").unwrap(),
-      text_info: SourceTextInfo::from_string("// 1\n1 + 1\n// 2".to_string()),
+      text: "// 1\n1 + 1\n// 2".into(),
       media_type: MediaType::JavaScript,
       capture_tokens: true,
       maybe_syntax: None,
@@ -359,9 +378,7 @@ mod test {
 
     let program = parse_module(ParseParams {
       specifier: ModuleSpecifier::parse("file:///my_file.js").unwrap(),
-      text_info: SourceTextInfo::from_string(
-        "class T { method() { #test in this; } }".to_string(),
-      ),
+      text: "class T { method() { #test in this; } }".into(),
       media_type: MediaType::JavaScript,
       capture_tokens: true,
       maybe_syntax: None,
@@ -384,7 +401,7 @@ mod test {
   fn should_panic_when_getting_tokens_and_tokens_not_captured() {
     let program = parse_module(ParseParams {
       specifier: ModuleSpecifier::parse("file:///my_file.js").unwrap(),
-      text_info: SourceTextInfo::from_string("// 1\n1 + 1\n// 2".to_string()),
+      text: "// 1\n1 + 1\n// 2".into(),
       media_type: MediaType::JavaScript,
       capture_tokens: false,
       maybe_syntax: None,
@@ -398,7 +415,7 @@ mod test {
   fn should_handle_parse_error() {
     let diagnostic = parse_module(ParseParams {
       specifier: ModuleSpecifier::parse("file:///my_file.js").unwrap(),
-      text_info: SourceTextInfo::from_string("t u".to_string()),
+      text: "t u".into(),
       media_type: MediaType::JavaScript,
       capture_tokens: true,
       maybe_syntax: None,
@@ -439,7 +456,7 @@ mod test {
   fn get_scope_analysis_false_parsed_source() -> ParsedSource {
     parse_module(ParseParams {
       specifier: ModuleSpecifier::parse("file:///my_file.js").unwrap(),
-      text_info: SourceTextInfo::from_string("// 1\n1 + 1\n// 2".to_string()),
+      text: "// 1\n1 + 1\n// 2".into(),
       media_type: MediaType::JavaScript,
       capture_tokens: false,
       maybe_syntax: None,
@@ -453,9 +470,7 @@ mod test {
   fn should_do_scope_analysis() {
     let parsed_source = parse_module(ParseParams {
       specifier: ModuleSpecifier::parse("file:///my_file.js").unwrap(),
-      text_info: SourceTextInfo::from_string(
-        "export function test() { const test = 2; test; } test()".to_string(),
-      ),
+      text: "export function test() { const test = 2; test; } test()".into(),
       media_type: MediaType::JavaScript,
       capture_tokens: true,
       maybe_syntax: None,
@@ -492,9 +507,7 @@ mod test {
   fn should_allow_scope_analysis_after_the_fact() {
     let parsed_source = parse_module(ParseParams {
       specifier: ModuleSpecifier::parse("file:///my_file.js").unwrap(),
-      text_info: SourceTextInfo::from_string(
-        "export function test() { const test = 2; test; } test()".to_string(),
-      ),
+      text: "export function test() { const test = 2; test; } test()".into(),
       media_type: MediaType::JavaScript,
       capture_tokens: true,
       maybe_syntax: None,
@@ -539,13 +552,11 @@ mod test {
   fn should_scope_analyze_typescript() {
     let parsed_source = parse_module(ParseParams {
       specifier: ModuleSpecifier::parse("file:///my_file.ts").unwrap(),
-      text_info: SourceTextInfo::from_string(
-        r#"import type { Foo } from "./foo.ts";
+      text: r#"import type { Foo } from "./foo.ts";
 function _bar(...Foo: Foo) {
   console.log(Foo);
 }"#
-          .to_string(),
-      ),
+        .into(),
       media_type: MediaType::TypeScript,
       capture_tokens: true,
       maybe_syntax: None,
@@ -650,7 +661,7 @@ function _bar(...Foo: Foo) {
   fn parse_ts_module(text: &str) -> Result<ParsedSource, ParseDiagnostic> {
     parse_module(ParseParams {
       specifier: ModuleSpecifier::parse("file:///my_file.ts").unwrap(),
-      text_info: SourceTextInfo::from_string(text.to_string()),
+      text: text.to_string().into(),
       media_type: MediaType::TypeScript,
       capture_tokens: false,
       maybe_syntax: None,

--- a/src/scopes.rs
+++ b/src/scopes.rs
@@ -359,12 +359,11 @@ mod tests {
   use crate::MediaType;
   use crate::ModuleSpecifier;
   use crate::ParseParams;
-  use crate::SourceTextInfo;
 
   fn test_scope(source_code: &str, test: impl Fn(Scope)) {
     let parsed_source = parse_module(ParseParams {
       specifier: ModuleSpecifier::parse("file:///my_file.js").unwrap(),
-      text_info: SourceTextInfo::from_string(source_code.to_string()),
+      text: source_code.to_string().into(),
       media_type: MediaType::TypeScript,
       capture_tokens: true,
       maybe_syntax: None,

--- a/src/transpiling/mod.rs
+++ b/src/transpiling/mod.rs
@@ -217,7 +217,7 @@ impl ParsedSource {
     let program = (*self.program()).clone();
     transpile(
       self.specifier().clone(),
-      self.text_info().text_str().to_string(),
+      self.text().to_string(),
       program,
       // we need the comments to be mutable, so make it single threaded
       self.comments().as_single_threaded(),
@@ -248,7 +248,7 @@ impl ParsedSource {
           inner: Arc::new(crate::ParsedSourceInner {
             specifier: inner.specifier,
             media_type: inner.media_type,
-            text_info: inner.text_info,
+            text: inner.text,
             comments: inner.comments,
             program,
             tokens: inner.tokens,
@@ -261,7 +261,7 @@ impl ParsedSource {
     };
     Ok(transpile(
       inner.specifier,
-      inner.text_info.text_str().to_string(),
+      inner.text.to_string(),
       program,
       // we need the comments to be mutable, so make it single threaded
       inner.comments.into_single_threaded(),
@@ -610,7 +610,7 @@ export class A {
     "#;
     let module = parse_module(ParseParams {
       specifier,
-      text_info: SourceTextInfo::from_string(source.to_string()),
+      text: source.into(),
       media_type: MediaType::TypeScript,
       capture_tokens: false,
       maybe_syntax: None,
@@ -669,7 +669,7 @@ export class A {
     let source = "using data = create();\nconsole.log(data);";
     let module = parse_module(ParseParams {
       specifier,
-      text_info: SourceTextInfo::from_string(source.to_string()),
+      text: source.into(),
       media_type: MediaType::TypeScript,
       capture_tokens: false,
       maybe_syntax: None,
@@ -772,7 +772,7 @@ try {
     "#;
     let module = parse_module(ParseParams {
       specifier,
-      text_info: SourceTextInfo::from_string(source.to_string()),
+      text: source.into(),
       media_type: MediaType::Tsx,
       capture_tokens: false,
       maybe_syntax: None,
@@ -803,7 +803,7 @@ try {
     "#;
     let module = parse_module(ParseParams {
       specifier,
-      text_info: SourceTextInfo::from_string(source.to_string()),
+      text: source.into(),
       media_type: MediaType::Tsx,
       capture_tokens: false,
       maybe_syntax: None,
@@ -838,7 +838,7 @@ function App() {
 }"#;
     let module = parse_module(ParseParams {
       specifier,
-      text_info: SourceTextInfo::from_string(source.to_string()),
+      text: source.into(),
       media_type: MediaType::Jsx,
       capture_tokens: false,
       maybe_syntax: None,
@@ -873,7 +873,7 @@ function App() {
 }"#;
     let module = parse_module(ParseParams {
       specifier,
-      text_info: SourceTextInfo::from_string(source.to_string()),
+      text: source.into(),
       media_type: MediaType::Jsx,
       capture_tokens: false,
       maybe_syntax: None,
@@ -914,7 +914,7 @@ function App() {
 }"#;
     let module = parse_module(ParseParams {
       specifier,
-      text_info: SourceTextInfo::from_string(source.to_string()),
+      text: source.into(),
       media_type: MediaType::Jsx,
       capture_tokens: false,
       maybe_syntax: None,
@@ -954,7 +954,7 @@ function App() {
 }"#;
     let module = parse_module(ParseParams {
       specifier,
-      text_info: SourceTextInfo::from_string(source.to_string()),
+      text: source.into(),
       media_type: MediaType::Jsx,
       capture_tokens: false,
       maybe_syntax: None,
@@ -1003,7 +1003,7 @@ function App() {
 }"#;
     let module = parse_module(ParseParams {
       specifier,
-      text_info: SourceTextInfo::from_string(source.to_string()),
+      text: source.into(),
       media_type: MediaType::Jsx,
       capture_tokens: false,
       maybe_syntax: None,
@@ -1055,7 +1055,7 @@ function App() {
     "#;
     let module = parse_module(ParseParams {
       specifier,
-      text_info: SourceTextInfo::from_string(source.to_string()),
+      text: source.into(),
       media_type: MediaType::TypeScript,
       capture_tokens: false,
       maybe_syntax: None,
@@ -1122,7 +1122,7 @@ _ts_decorate([
     "#;
     let module = parse_module(ParseParams {
       specifier,
-      text_info: SourceTextInfo::from_string(source.to_string()),
+      text: source.into(),
       media_type: MediaType::TypeScript,
       capture_tokens: false,
       maybe_syntax: None,
@@ -1154,7 +1154,7 @@ _ts_decorate([
     let source = "";
     let module = parse_module(ParseParams {
       specifier,
-      text_info: SourceTextInfo::from_string(source.to_string()),
+      text: source.into(),
       media_type: MediaType::TypeScript,
       capture_tokens: false,
       maybe_syntax: None,
@@ -1198,7 +1198,7 @@ _ts_decorate([
     "#;
     let module = parse_module(ParseParams {
       specifier,
-      text_info: SourceTextInfo::from_string(source.to_string()),
+      text: source.into(),
       media_type: MediaType::TypeScript,
       capture_tokens: false,
       maybe_syntax: None,
@@ -1245,7 +1245,7 @@ export function g() {
   "#;
     let module = parse_module(ParseParams {
       specifier,
-      text_info: SourceTextInfo::from_string(source.to_string()),
+      text: source.into(),
       media_type: MediaType::TypeScript,
       capture_tokens: false,
       maybe_syntax: None,
@@ -1281,7 +1281,7 @@ for (let i = 0; i < testVariable >> 1; i++) callCount++;
   "#;
     let module = parse_module(ParseParams {
       specifier,
-      text_info: SourceTextInfo::from_string(source.to_string()),
+      text: source.into(),
       media_type: MediaType::TypeScript,
       capture_tokens: false,
       maybe_syntax: None,
@@ -1308,7 +1308,7 @@ for (let i = 0; i < testVariable >> 1; i++) callCount++;
 };"#;
     let parsed_source = parse_module(ParseParams {
       specifier,
-      text_info: SourceTextInfo::from_string(source.to_string()),
+      text: source.into(),
       media_type: MediaType::Tsx,
       capture_tokens: false,
       maybe_syntax: None,
@@ -1384,7 +1384,7 @@ for (let i = 0; i < testVariable >> 1; i++) callCount++;
       ModuleSpecifier::parse("https://deno.land/x/mod.ts").unwrap();
     let parsed_source = parse_module(ParseParams {
       specifier,
-      text_info: SourceTextInfo::from_string(source.to_string()),
+      text: source.into(),
       media_type: MediaType::TypeScript,
       capture_tokens: false,
       maybe_syntax: None,
@@ -1406,12 +1406,10 @@ for (let i = 0; i < testVariable >> 1; i++) callCount++;
     let p = parse_module(ParseParams {
       specifier: ModuleSpecifier::parse("file:///Users/ib/dev/deno/foo.ts")
         .unwrap(),
-      text_info: SourceTextInfo::from_string(
-        r#"export default function () {
+      text: r#"export default function () {
     return "📣❓";
 }"#
-          .to_string(),
-      ),
+        .into(),
       media_type: MediaType::TypeScript,
       capture_tokens: true,
       scope_analysis: false,
@@ -1440,7 +1438,7 @@ for (let i = 0; i < testVariable >> 1; i++) callCount++;
       r#"const a = <Foo><span>hello</span>foo<Bar><p>asdf</p></Bar></Foo>;"#;
     let module = parse_module(ParseParams {
       specifier,
-      text_info: SourceTextInfo::from_string(source.to_string()),
+      text: source.into(),
       media_type: MediaType::Tsx,
       capture_tokens: false,
       maybe_syntax: None,
@@ -1484,7 +1482,7 @@ const a = _jsx(Foo, {
     let source = r#"{ const foo = "bar"; };"#;
     let module = parse_module(ParseParams {
       specifier,
-      text_info: SourceTextInfo::from_string(source.to_string()),
+      text: source.into(),
       media_type: MediaType::Tsx,
       capture_tokens: false,
       maybe_syntax: None,
@@ -1516,7 +1514,7 @@ const a = _jsx(Foo, {
     let source = r#"{ const foo = "bar"; };"#;
     let module = parse_module(ParseParams {
       specifier,
-      text_info: SourceTextInfo::from_string(source.to_string()),
+      text: source.into(),
       media_type: MediaType::Tsx,
       capture_tokens: false,
       maybe_syntax: None,
@@ -1554,7 +1552,7 @@ const a = _jsx(Foo, {
     let source = r#"{ const foo = "bar"; };"#;
     let module = parse_module(ParseParams {
       specifier,
-      text_info: SourceTextInfo::from_string(source.to_string()),
+      text: source.into(),
       media_type: MediaType::Tsx,
       capture_tokens: false,
       maybe_syntax: None,
@@ -1593,7 +1591,7 @@ const a = _jsx(Foo, {
     let source = r#"{ const foo = "bar"; };"#;
     let module = parse_module(ParseParams {
       specifier,
-      text_info: SourceTextInfo::from_string(source.to_string()),
+      text: source.into(),
       media_type: MediaType::Tsx,
       capture_tokens: false,
       maybe_syntax: None,
@@ -1626,7 +1624,7 @@ const a = _jsx(Foo, {
     let source = r#"const foo: string = "bar";"#;
     let module = parse_module(ParseParams {
       specifier,
-      text_info: SourceTextInfo::from_string(source.to_string()),
+      text: source.into(),
       media_type: MediaType::TypeScript,
       capture_tokens: false,
       maybe_syntax: None,
@@ -1655,7 +1653,7 @@ const a = _jsx(Foo, {
     let source = r#"const foo: string = "bar";"#;
     let module = parse_module(ParseParams {
       specifier,
-      text_info: SourceTextInfo::from_string(source.to_string()),
+      text: source.into(),
       media_type: MediaType::TypeScript,
       capture_tokens: false,
       maybe_syntax: None,
@@ -1700,7 +1698,7 @@ const a = _jsx(Foo, {
     let source = r#"const foo: string = "bar";"#;
     let module = parse_module(ParseParams {
       specifier,
-      text_info: SourceTextInfo::from_string(source.to_string()),
+      text: source.into(),
       media_type: MediaType::TypeScript,
       capture_tokens: false,
       maybe_syntax: None,
@@ -1762,7 +1760,7 @@ export function formatter(record: Record) {
 "#;
     let module = parse_module(ParseParams {
       specifier,
-      text_info: SourceTextInfo::from_string(source.to_string()),
+      text: source.into(),
       media_type: MediaType::TypeScript,
       capture_tokens: false,
       maybe_syntax: None,

--- a/src/transpiling/mod.rs
+++ b/src/transpiling/mod.rs
@@ -605,7 +605,6 @@ mod tests {
   use crate::ModuleSpecifier;
   use crate::ParseParams;
   use crate::SourceMapOption;
-  use crate::SourceTextInfo;
 
   use base64::Engine;
   use pretty_assertions::assert_eq;

--- a/src/transpiling/mod.rs
+++ b/src/transpiling/mod.rs
@@ -228,7 +228,7 @@ impl ParsedSource {
       // do a deep clone of the globals, but that requires changes in swc and this
       // is unlikely to be a problem in practice
       self.globals(),
-      &resolve_transpile_options(self.inner.media_type, transpile_options),
+      &resolve_transpile_options(self.0.media_type, transpile_options),
       emit_options,
       self.diagnostics(),
     )
@@ -239,26 +239,25 @@ impl ParsedSource {
     transpile_options: &TranspileOptions,
     emit_options: &EmitOptions,
   ) -> Result<Result<EmittedSourceBytes, TranspileError>, ParsedSource> {
-    let inner = match Arc::try_unwrap(self.inner) {
+    let inner = match Arc::try_unwrap(self.0) {
       Ok(inner) => inner,
-      Err(inner) => return Err(ParsedSource { inner }),
+      Err(inner) => return Err(ParsedSource(inner)),
     };
     let program = match Arc::try_unwrap(inner.program) {
       Ok(program) => program,
       Err(program) => {
-        return Err(ParsedSource {
-          inner: Arc::new(crate::ParsedSourceInner {
-            specifier: inner.specifier,
-            media_type: inner.media_type,
-            text: inner.text,
-            comments: inner.comments,
-            program,
-            tokens: inner.tokens,
-            syntax_contexts: inner.syntax_contexts,
-            diagnostics: inner.diagnostics,
-            globals: inner.globals,
-          }),
-        })
+        return Err(ParsedSource(Arc::new(crate::ParsedSourceInner {
+          specifier: inner.specifier,
+          media_type: inner.media_type,
+          text: inner.text,
+          source_text_info: inner.source_text_info,
+          comments: inner.comments,
+          program,
+          tokens: inner.tokens,
+          syntax_contexts: inner.syntax_contexts,
+          diagnostics: inner.diagnostics,
+          globals: inner.globals,
+        })))
       }
     };
     Ok(transpile(


### PR DESCRIPTION
This is taking 2% of execution in a benchmark I have. We don't need to create this when transpiling in Deno.