### PR TITLE
feat: enhance dynamic import with template argument

### DIFF
--- a/src/dep.rs
+++ b/src/dep.rs
@@ -6,6 +6,7 @@ use ast::BinExpr;
 use ast::Module;
 use serde::Deserialize;
 use serde::Serialize;
+use swc_ecma_ast::{Ident, IdentName, MemberExpr, MemberProp};
 
 use crate::swc::ast;
 use crate::swc::ast::Callee;
@@ -161,6 +162,8 @@ pub enum DynamicArgument {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DynamicTemplatePart {
   String(Atom),
+  /// An member expression that may be analyzed.
+  MemberExpr(Atom, Atom, Atom),
   /// An expression that could not be analyzed.
   Expr,
 }
@@ -304,8 +307,39 @@ impl<'a> Visit for DependencyCollector<'a> {
             if cooked.len() > 0 {
               parts.push(DynamicTemplatePart::String(cooked.clone()));
             }
-            if tpl.exprs.get(i).is_some() {
-              parts.push(DynamicTemplatePart::Expr);
+
+            let mut is_member_expr = false;
+
+            if let Some(expr) = tpl.exprs.get(i) {
+              match **expr {
+                Expr::Member(MemberExpr {
+                  prop: MemberProp::Ident(IdentName { sym: ref sym2, .. }),
+                  ref obj,
+                  ..
+                }) => match **obj {
+                  Expr::Member(MemberExpr {
+                    prop: MemberProp::Ident(IdentName { sym: ref sym1, .. }),
+                    obj: ref obj1,
+                    ..
+                  }) => match **obj1 {
+                    Expr::Ident(Ident { ref sym, .. }) => {
+                      parts.push(DynamicTemplatePart::MemberExpr(
+                        sym.clone(),
+                        sym1.clone(),
+                        sym2.clone(),
+                      ));
+                      is_member_expr = true;
+                    }
+                    _ => {}
+                  },
+                  _ => {}
+                },
+                _ => {}
+              }
+
+              if !is_member_expr {
+                parts.push(DynamicTemplatePart::Expr);
+              }
             }
           }
           DynamicArgument::Template(parts)
@@ -881,6 +915,7 @@ const d9 = await import("./foo/" + value + ".ts");
 const d10 = await import(value + ".ts");
 const d11 = await import("./foo/" - value);
 const d12 = await import(expr);
+const d13 = await import(`${Deno.build.target}/test`);
 "#;
     let (start_pos, dependencies) = helper("file:///test.ts", source);
     assert_eq!(
@@ -1005,6 +1040,27 @@ const d12 = await import(expr);
           range: SourceRange::new(start_pos + 511, start_pos + 523),
           argument: DynamicArgument::Expr,
           argument_range: SourceRange::new(start_pos + 518, start_pos + 522),
+          import_attributes: ImportAttributes::None,
+        }
+        .into(),
+        DynamicDependencyDescriptor {
+          leading_comments: Vec::new(),
+          range: SourceRange {
+            start: start_pos + 543,
+            end: start_pos + 578,
+          },
+          argument: DynamicArgument::Template(vec![
+            DynamicTemplatePart::MemberExpr(
+              JsWord::from("Deno"),
+              JsWord::from("build"),
+              JsWord::from("target")
+            ),
+            DynamicTemplatePart::String(JsWord::from("/test")),
+          ]),
+          argument_range: SourceRange {
+            start: start_pos + 550,
+            end: start_pos + 577,
+          },
           import_attributes: ImportAttributes::None,
         }
         .into(),


### PR DESCRIPTION
We now support dynamic imports with template arguments:
```ts
import("./a/${test}/.mod.ts")
```
This will include all files matching `./a/**/mod.ts`.

## The problem:
Many libraries that use Deno FFI require multiple files compiled for specific platforms. For example:

Library entry: 
- `https://jsr.io/@scope/mylib/0.0.1/mod.ts`
```ts
const lib = await import(`./ffi/${Deno.build.target}/ffi.ts`);
```
The files compiled for multiple platforms:
- `https://jsr.io/@scope/mylib/0.0.1/ffi/aarch64-apple-darwin/ffi.ts`
- `https://jsr.io/@scope/mylib/0.0.1/ffi/x86_64-unknown-linux-gnu/ffi.ts`
- `https://jsr.io/@scope/mylib/0.0.1/ffi/x86_64-pc-windows-msvc/ffi.ts`
...

In our project:
```ts
// main.ts
import xxx from "jsr:@scope/mylib"
...
```

Then use `deno compile`:
```ts
deno compile --unstable-ffi  --include ... main.ts
```

-----
Currently, we have to manually --include all the files regardless of the actual platform it will run on:
```ts
deno compile --unstable-ffi  --include https://jsr.io/@scope/mylib/0.0.1/ffi/aarch64-apple-darwin/ffi.ts --include https://jsr.io/@scope/mylib/0.0.1/ffi/x86_64-unknown-linux-gnu/ffi.ts main.ts
```
- This is inconvenient, especially after updating `jsr:@scope/mylib`, as we have to carefully `--include` the correct version:
```diff
- --include https://jsr.io/@scope/mylib/0.0.1/ffi/aarch64-apple-darwin/ffi.ts
+ --include https://jsr.io/@scope/mylib/0.0.2/ffi/aarch64-apple-darwin/ffi.ts
```
- It also increases the bundle size since we actually need only one of the files.

----
Another option is to statically import all the FFI files, as shown [here](https://github.com/deno-windowing/dwm/blob/d52156c48ada7d1aa126d84425e3405edc9e524f/src/platform/glfw/ffi.ts#L5):
 
<img width="739" alt="截屏2024-08-06 下午6 37 22" src="https://github.com/user-attachments/assets/23d0674a-53c6-48ec-b2da-5ef9a6d8f2d8">

it will be more complicated to maintain the library, and also will incrase the compiled bundle size.

## Proposal
Analyze the expressions in the template argument in specific cases if they are known at compile time:
```shell
import(`./${Deno.build.target}/mod.ts`)
```
We can replace `${Deno.build.target}` with correct `target` 
```shell
import("./aarch64-apple-darwin/mod.ts")
```
which then become statically analyzable.


## Proof of work
I have created a patch and some tests for deno_graph which rely on this PR:
https://github.com/denoland/deno_graph/compare/main...Mutefish0:deno_graph:feat-enhance-dynamic-import#diff-7ff815b68943f08bef79f083c09e55ca8c18db8e25033034b12fa31f1d43dab4R438


## Related Issues
https://github.com/denoland/deno/issues/24871
