### PR TITLE
fix: add back `IntoSwcFileName`

### DIFF
--- a/src/source_map.rs
+++ b/src/source_map.rs
@@ -6,7 +6,7 @@ use crate::swc::common::FileName;
 use crate::swc::common::SourceFile;
 use crate::ModuleSpecifier;
 
-/// This is used in JSR, so don't remove it.
+// this is used in JSR, so don't remove it
 pub trait IntoSwcFileName {
   fn into_file_name(self) -> FileName;
 }

--- a/src/source_map.rs
+++ b/src/source_map.rs
@@ -2,9 +2,26 @@
 
 use std::rc::Rc;
 
+use crate::swc::common::FileName;
 use crate::swc::common::SourceFile;
-
 use crate::ModuleSpecifier;
+
+/// This is used in JSR, so don't remove it.
+pub trait IntoSwcFileName {
+  fn into_file_name(self) -> FileName;
+}
+
+impl IntoSwcFileName for ModuleSpecifier {
+  fn into_file_name(self) -> FileName {
+    FileName::Url(self)
+  }
+}
+
+impl IntoSwcFileName for String {
+  fn into_file_name(self) -> FileName {
+    FileName::Custom(self)
+  }
+}
 
 #[derive(Clone, Default)]
 pub struct SourceMap {
@@ -12,11 +29,12 @@ pub struct SourceMap {
 }
 
 impl SourceMap {
-  pub fn single(specifier: ModuleSpecifier, source: String) -> Self {
+  pub fn single(file_name: impl IntoSwcFileName, source: String) -> Self {
     let map = Self::default();
-    map
-      .inner
-      .new_source_file(Rc::new(swc_common::FileName::Url(specifier)), source);
+    map.inner.new_source_file(
+      Rc::new(IntoSwcFileName::into_file_name(file_name)),
+      source,
+    );
     map
   }
 
@@ -26,11 +44,12 @@ impl SourceMap {
 
   pub fn new_source_file(
     &self,
-    specifier: ModuleSpecifier,
+    file_name: impl IntoSwcFileName,
     source: String,
   ) -> Rc<SourceFile> {
-    self
-      .inner
-      .new_source_file(Rc::new(swc_common::FileName::Url(specifier)), source)
+    self.inner.new_source_file(
+      Rc::new(IntoSwcFileName::into_file_name(file_name)),
+      source,
+    )
   }
 }


### PR DESCRIPTION
This was removed because it wasn't used, but actually it's used in JSR... so added back with a comment.