### PR TITLE
perf: pre-allocate text change string capacity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,6 +236,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sourcemap",
+ "string_capacity",
  "swc_atoms",
  "swc_bundler",
  "swc_common",
@@ -457,9 +458,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "lazy_static"
@@ -940,6 +941,15 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "string_capacity"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d66c912ea6a5e9d1b1cc1be9c72325a5502f0b868578a7dd0fa97bb710626c2"
+dependencies = [
+ "itoa",
+]
 
 [[package]]
 name = "string_enum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ swc_visit = { version = "=0.6.2", optional = true }
 swc_visit_macros = { version = "=0.5.13", optional = true }
 # just for error handling
 sourcemap = { version = "9.0.0", optional = true }
+string_capacity = "0.1.4"
 thiserror = "1.0.58"
 
 [dev-dependencies]


### PR DESCRIPTION
Pretty trivial to maintain this now.

```rs
use deno_ast::apply_text_changes;
use deno_ast::TextChange;

fn main() {
  let mut value = 0;
  let mut large_string = String::new();
  for _ in 0..10000 {
    large_string.push_str("testing this out");
  }
  let changes = vec![TextChange::new(9, 10, "z".to_string()), TextChange::new(4, 6, "y".to_string()), TextChange::new(1, 2, "x".to_string())];
  for _ in 0..10000 {
    let final_str = apply_text_changes("testing this out", changes.clone());
    value += final_str.len();
  }
  eprintln!("start: {}", value);
}
```

```
> hyperfine --warmup 4 "before.exe" "after.exe"
Benchmark 1: before.exe
  Time (mean ± σ):       6.9 ms ±   0.6 ms    [User: 1.1 ms, System: 1.0 ms]
  Range (min … max):     5.9 ms …   9.5 ms    259 runs

Benchmark 2: after.exe
  Time (mean ± σ):       6.4 ms ±   0.5 ms    [User: 0.2 ms, System: 0.8 ms]
  Range (min … max):     5.6 ms …   8.5 ms    302 runs

Summary
  after.exe ran
    1.08 ± 0.12 times faster than before.exe
```

Closes https://github.com/denoland/deno_ast/issues/140