### PR TITLE
chore: update deno_media_type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,9 +320,9 @@ dependencies = [
 
 [[package]]
 name = "deno_media_type"
-version = "0.2.1"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf552fbdedbe81c89705349d7d2485c7051382b000dfddbdbf7fc25931cf83"
+checksum = "3d9080fcfcea53bcd6eea1916217bd5611c896f3a0db4c001a859722a1258a47"
 dependencies = [
  "data-url",
  "serde",

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -371,6 +371,8 @@ pub fn get_syntax(media_type: MediaType) -> Syntax {
     | MediaType::Wasm
     | MediaType::SourceMap
     | MediaType::Css
+    | MediaType::Sql
+    | MediaType::Html
     | MediaType::Unknown => Syntax::Es(EsSyntax {
       allow_return_outside_function: true,
       allow_super_outside_method: true,


### PR DESCRIPTION
This PR updates deno_media_type to v0.2.8 and fixes the build.