### PR TITLE
chore: upgrade some dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1102,9 +1102,9 @@ dependencies = [
 
 [[package]]
 name = "sourcemap"
-version = "9.0.0"
+version = "9.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dab08a862c70980b8e23698b507e272317ae52a608a164a844111f5372374f1f"
+checksum = "27c4ea7042fd1a155ad95335b5d505ab00d5124ea0332a06c8390d200bb1a76a"
 dependencies = [
  "base64-simd",
  "bitvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -832,9 +832,9 @@ checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pretty_assertions"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
 dependencies = [
  "diff",
  "yansi",
@@ -2212,9 +2212,9 @@ dependencies = [
 
 [[package]]
 name = "yansi"
-version = "0.5.1"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1046,9 +1046,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.121"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ab380d7d9f22ef3f21ad3e6c1ebe8e4fc7a2000ccba2e4d71fc96f15b2cb609"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "indexmap",
  "itoa",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -721,9 +721,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
 
 [[package]]
 name = "outref"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,9 +331,9 @@ dependencies = [
 
 [[package]]
 name = "deno_terminal"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daef12499e89ee99e51ad6000a91f600d3937fb028ad4918af76810c5bc9e0d5"
+checksum = "23f71c27009e0141dedd315f1dfa3ebb0a6ca4acce7c080fac576ea415a465f6"
 dependencies = [
  "once_cell",
  "termcolor",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,6 +93,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "base64-simd"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,7 +259,7 @@ dependencies = [
 name = "deno_ast"
 version = "0.46.2"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "deno_error",
  "deno_media_type",
  "deno_terminal",
@@ -1708,7 +1714,7 @@ version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "311218980029ea376a1f53292418d852d50b461d15d9d39f830abf0d1c3bdd6c"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "dashmap",
  "indexmap",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1140,9 +1140,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_capacity"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d66c912ea6a5e9d1b1cc1be9c72325a5502f0b868578a7dd0fa97bb710626c2"
+checksum = "fcd14cb3a5abda6d2626370785f5f788b22e95476f597159faa4a2cc2966961a"
 dependencies = [
  "itoa",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,9 +299,9 @@ dependencies = [
 
 [[package]]
 name = "deno_error"
-version = "0.5.0"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a4a933a7cdb395adbfaf418fc4a93f14416fdf61d660d0cd67eca57162552c"
+checksum = "19fae9fe305307b5ef3ee4e8244c79cffcca421ab0ce8634dea0c6b1342f220f"
 dependencies = [
  "deno_error_macro",
  "libc",
@@ -309,9 +309,9 @@ dependencies = [
 
 [[package]]
 name = "deno_error_macro"
-version = "0.5.0"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0480c64271ddab066186fe22a32e27cc87ab84e4a7779d060c5e4dc894f9c1fa"
+checksum = "5abb2556e91848b66f562451fcbcdee2a3b7c88281828908dcf7cca355f5d997"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1020,18 +1020,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.204"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.204"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1938,18 +1938,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.3"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.3"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,5 +81,5 @@ string_capacity = "0.1.5"
 thiserror = "2"
 
 [dev-dependencies]
-pretty_assertions = "1.3.0"
+pretty_assertions = "1.4.1"
 serde_json = { version = "1.0.87", features = ["preserve_order"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ deno_terminal = "0.2.2"
 deno_error = "0.5.6"
 
 dprint-swc-ext = "0.22.1"
-once_cell = "1.19.0"
+once_cell = "1.21.1"
 percent-encoding = "2.3.1"
 serde = { version = "1.0.144", features = ["derive"] }
 text_lines = { version = "0.6.0", features = ["serialization"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ visit = ["swc_ecma_visit", "swc_visit", "swc_visit_macros", "swc_macros_common"]
 
 [dependencies]
 base64 = { version = "0.22.1", optional = true }
-deno_media_type = "0.2.1"
+deno_media_type = "0.2.8"
 deno_terminal = "0.2.2"
 deno_error = "0.5.6"
 
@@ -41,7 +41,7 @@ once_cell = "1.21.1"
 percent-encoding = "2.3.1"
 serde = { version = "1.0.219", features = ["derive"] }
 text_lines = { version = "0.6.0", features = ["serialization"] }
-url = { version = "2.3.1", features = ["serde"] }
+url = { version = "2.5.4", features = ["serde"] }
 unicode-width = "0.2.0"
 
 # swc's version bumping is very buggy and there will often be patch versions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ view = ["dprint-swc-ext/view"]
 visit = ["swc_ecma_visit", "swc_visit", "swc_visit_macros", "swc_macros_common"]
 
 [dependencies]
-base64 = { version = "0.21.6", optional = true }
+base64 = { version = "0.22.1", optional = true }
 deno_media_type = "0.2.1"
 deno_terminal = "0.2.2"
 deno_error = "0.5.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ visit = ["swc_ecma_visit", "swc_visit", "swc_visit_macros", "swc_macros_common"]
 base64 = { version = "0.21.6", optional = true }
 deno_media_type = "0.2.1"
 deno_terminal = "0.2.2"
-deno_error = "0.5.0"
+deno_error = "0.5.6"
 
 dprint-swc-ext = "0.22.1"
 once_cell = "1.19.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ swc_trace_macro = { version = "=2.0.0", optional = true }
 swc_visit = { version = "=2.0.0", optional = true }
 swc_visit_macros = { version = "=0.5.13", optional = true }
 # just for error handling
-sourcemap = { version = "9.0.0", optional = true }
+sourcemap = { version = "9.1.2", optional = true }
 string_capacity = "0.1.5"
 thiserror = "2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ visit = ["swc_ecma_visit", "swc_visit", "swc_visit_macros", "swc_macros_common"]
 [dependencies]
 base64 = { version = "0.21.6", optional = true }
 deno_media_type = "0.2.1"
-deno_terminal = "0.2.0"
+deno_terminal = "0.2.2"
 deno_error = "0.5.0"
 
 dprint-swc-ext = "0.22.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ deno_error = "0.5.6"
 dprint-swc-ext = "0.22.1"
 once_cell = "1.21.1"
 percent-encoding = "2.3.1"
-serde = { version = "1.0.144", features = ["derive"] }
+serde = { version = "1.0.219", features = ["derive"] }
 text_lines = { version = "0.6.0", features = ["serialization"] }
 url = { version = "2.3.1", features = ["serde"] }
 unicode-width = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ swc_visit = { version = "=2.0.0", optional = true }
 swc_visit_macros = { version = "=0.5.13", optional = true }
 # just for error handling
 sourcemap = { version = "9.0.0", optional = true }
-string_capacity = "0.1.4"
+string_capacity = "0.1.5"
 thiserror = "2"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,4 +82,4 @@ thiserror = "2"
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"
-serde_json = { version = "1.0.87", features = ["preserve_order"] }
+serde_json = { version = "1.0.140", features = ["preserve_order"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ swc_visit_macros = { version = "=0.5.13", optional = true }
 # just for error handling
 sourcemap = { version = "9.1.2", optional = true }
 string_capacity = "0.1.5"
-thiserror = "2"
+thiserror = "2.0.12"
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"


### PR DESCRIPTION
- **upgrade deno_terminal to 0.2.2**
- **upgrade deno_error to 0.5.6**
- **upgrade once_cell to 1.21.1**
- **upgrade serde to 1.0.219**
- **upgrade string_capacity to 0.1.5**
- **upgrade base64 to 0.22.1**
- **upgrade sourcemap to 9.1.2**
- **upgrade pretty_assertions to 1.4.1**
- **upgrade serde_json to 1.0.140**
- **upgrade thiserror to 2.0.12**
- **update url dependency to 2.5.4**
