### PR TITLE
feat: add version export

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,9 @@
 #![deny(clippy::print_stderr)]
 #![deny(clippy::print_stdout)]
 
+/// Version of this crate, which may be useful for emit caches.
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 #[cfg(feature = "cjs")]
 mod cjs_parse;
 mod comments;


### PR DESCRIPTION
Right now we're busting the emit cache on CLI version, but we could bust it on deno_ast version instead probably.