### PR TITLE
fix: avoid double traversal in assign visitor

### DIFF
--- a/src/cjs_parse.rs
+++ b/src/cjs_parse.rs
@@ -250,8 +250,6 @@ impl Visit for CjsVisitor {
       AssignTarget::Simple(SimpleAssignTarget::Ident(left_ident)) => {
         if is_exports_ident(&left_ident.id) {
           self.visit_exports_right_expr(&assign_expr.right);
-        } else if let Some(right_expr) = assign_expr.right.as_assign() {
-          self.visit_assign_expr(right_expr);
         }
       }
       AssignTarget::Simple(SimpleAssignTarget::Member(left_member)) => {
@@ -263,9 +261,6 @@ impl Visit for CjsVisitor {
           // * `exports.something = other`
           if let Some(prop_name) = get_member_prop_text(&left_member.prop) {
             self.add_export(prop_name);
-            if let Some(right_expr) = assign_expr.right.as_assign() {
-              self.visit_assign_expr(right_expr);
-            }
           } else if let Some(right_member) = assign_expr.right.as_member() {
             // check for:
             // * `exports[key] = _something[key];
@@ -278,15 +273,9 @@ impl Visit for CjsVisitor {
               self.add_reexport(&require_value);
             }
           }
-        } else if let Some(right_expr) = assign_expr.right.as_assign() {
-          self.visit_assign_expr(right_expr);
         }
       }
-      _ => {
-        if let Some(right_expr) = assign_expr.right.as_assign() {
-          self.visit_assign_expr(right_expr);
-        }
-      }
+      _ => {}
     }
   }
 }


### PR DESCRIPTION
Split up from:
- https://github.com/denoland/deno_ast/pull/328

The ref PR is now scanned recursively, so it should prevent double traversal.